### PR TITLE
[feat] BE. Github OAuth 를 통한 사용자 이메일 정보 받아오기

### DIFF
--- a/server/src/auth/auth.controller.ts
+++ b/server/src/auth/auth.controller.ts
@@ -8,7 +8,7 @@ import {
   Delete,
   Query,
 } from '@nestjs/common';
-import { AuthService } from './auth.service';
+import { AuthService, UserInfo } from './auth.service';
 
 @Controller('/auth')
 export class AuthController {
@@ -16,21 +16,24 @@ export class AuthController {
 
   @Get('/google-callback')
   async GoogleCallback(@Query('code') code: string) {
-    const email = await this.authService.getGoogleInfo(code);
+    const user: UserInfo = await this.authService.getGoogleInfo(code);
+
     //DB에서 유저 확인
     //없으면 회원가입으로 redirect
     //있으면 메인으로 redirect
-    return email;
+
+    return user;
   }
 
   @Get('github-callback')
   async GithubCallback(@Query('code') code: string) {
-    const email = await this.authService.getGithubInfo(code);
+    const user: UserInfo = await this.authService.getGithubInfo(code);
 
+    //세션에 저장
     //DB에서 유저 확인
     //없으면 회원가입으로 redirect
     //있으면 메인으로 redirect
 
-    return email;
+    return user;
   }
 }

--- a/server/src/auth/auth.controller.ts
+++ b/server/src/auth/auth.controller.ts
@@ -22,4 +22,15 @@ export class AuthController {
     //있으면 메인으로 redirect
     return email;
   }
+
+  @Get('github-callback')
+  async GithubCallback(@Query('code') code: string) {
+    const email = await this.authService.getGithubInfo(code);
+
+    //DB에서 유저 확인
+    //없으면 회원가입으로 redirect
+    //있으면 메인으로 redirect
+
+    return email;
+  }
 }

--- a/server/src/auth/auth.service.ts
+++ b/server/src/auth/auth.service.ts
@@ -6,6 +6,7 @@ const GOOGLE_REDIRECT_URL = 'http://localhost:3001/auth/google-callback';
 const GOOGLE_INFO_URL = `https://www.googleapis.com/oauth2/v3/userinfo`;
 
 const GITHUB_TOKEN_URL = 'https://github.com/login/oauth/access_token';
+const GITHUB_API_URL = 'https://api.github.com/';
 
 @Injectable()
 export class AuthService {
@@ -39,7 +40,11 @@ export class AuthService {
   async getGithubInfo(authCode: string): Promise<string> {
     const accessToken = await this.getGithubAccessToken(authCode);
 
-    return '';
+    const { data: emails } = await axios.get(GITHUB_API_URL + 'user/emails', {
+      headers: { Authorization: `token ${accessToken}` },
+    });
+
+    return emails[0].email;
   }
 
   private async getGithubAccessToken(code: string): Promise<string> {

--- a/server/src/auth/auth.service.ts
+++ b/server/src/auth/auth.service.ts
@@ -5,6 +5,8 @@ const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token';
 const GOOGLE_REDIRECT_URL = 'http://localhost:3001/auth/google-callback';
 const GOOGLE_INFO_URL = `https://www.googleapis.com/oauth2/v3/userinfo`;
 
+const GITHUB_TOKEN_URL = 'https://github.com/login/oauth/access_token';
+
 @Injectable()
 export class AuthService {
   async getGoogleInfo(authCode: string): Promise<string> {
@@ -31,6 +33,26 @@ export class AuthService {
         code: code,
       },
     });
+    return data['access_token'];
+  }
+
+  async getGithubInfo(authCode: string): Promise<string> {
+    const accessToken = await this.getGithubAccessToken(authCode);
+
+    return '';
+  }
+
+  private async getGithubAccessToken(code: string): Promise<string> {
+    const body = {
+      client_id: process.env.GITHUB_CLIENT_ID,
+      client_secret: process.env.GITHUB_CLIENT_SECRET,
+      code,
+    };
+
+    const { data } = await axios.post(GITHUB_TOKEN_URL, body, {
+      headers: { Accept: 'application/json' },
+    });
+
     return data['access_token'];
   }
 }

--- a/server/src/auth/auth.service.ts
+++ b/server/src/auth/auth.service.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import axios from 'axios';
 
-// const GOOGLE_AUTH_URL = 'https://accounts.google.com/o/oauth2/v2/auth';
 const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token';
 const GOOGLE_REDIRECT_URL = 'http://localhost:3001/auth/google-callback';
 const GOOGLE_INFO_URL = `https://www.googleapis.com/oauth2/v3/userinfo`;
@@ -9,7 +8,7 @@ const GOOGLE_INFO_URL = `https://www.googleapis.com/oauth2/v3/userinfo`;
 @Injectable()
 export class AuthService {
   async getGoogleInfo(authCode: string): Promise<string> {
-    const accessToken = await this.getAccessToken(authCode);
+    const accessToken = await this.getGoogleAccessToken(authCode);
 
     const { data } = await axios.get(
       `${GOOGLE_INFO_URL}?access_token=${accessToken}`,
@@ -17,7 +16,7 @@ export class AuthService {
     return data['email'];
   }
 
-  private async getAccessToken(code: string): Promise<string> {
+  private async getGoogleAccessToken(code: string): Promise<string> {
     const { data } = await axios({
       method: 'POST',
       url: GOOGLE_TOKEN_URL,

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -7,8 +7,10 @@ dotenv.config({
   path: path.resolve('.env'),
 });
 
+const PORT = 3001;
+
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
-  await app.listen(3001);
+  await app.listen(PORT);
 }
 bootstrap();


### PR DESCRIPTION
## 📕 제목

- https://github.com/boostcampwm-2022/web25-SCOPA/issues/3

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] Google OAuth 의 access token 을 받아오는 함수명을 getAccessToken() -> getGoogleAccessToken 으로 변경
   - Github OAuth 의 access token 을 받아오는 로직의 함수와 겹칠 수 있다고 판단해서 함수명을 더 구체화 했습니다.
- [x] Github OAuth App 을 등록합니다.
- [x] client_id 와 client_secret 저장하기
- [x] 클라이언트를 Github 인증 서버로 보내기
- [x] 콜백 주소로 요청 온 클라이언트의 code 값을 이용하여 Github authorization server 에서 access token 받아오기
- [x] access token 을 이용하여 Github resource server 에 사용자의 이메일 정보 요청하기

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- `server/src/auth/auth.controller.ts` 와 `server/src/auth/auth.service.ts` 파일을 중점적으로 보면 됩니다.
- `server/main.ts` 의 경우, 포트 번호를 `const` 로 빼줬습니다.
