### PR TITLE
[Feat] FE. 상세 페이지 레이아웃 잡기

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -10,7 +10,7 @@ const App = () => {
       <Route path='/' element={<CheckLogin />}>
         <Route path='/' element={<CommonLayout />}>
           <Route path='/' element={<MainPage />} />
-          <Route path='/details/:id' element={<DetailPage />} />
+          <Route path='/detail/:id' element={<DetailPage />} />
         </Route>
         <Route path='/' element={<LoginLayout />}>
           <Route path='/login' element={<LoginPage />} />

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,6 +1,6 @@
 import { Routes, Route } from 'react-router-dom';
 
-import { LoginPage, MainPage, RegisterPage, TestPage } from 'pages';
+import { DetailPage, LoginPage, MainPage, RegisterPage, TestPage } from 'pages';
 import { CheckLogin, LoginLayout, CommonLayout } from 'common';
 
 // 라우팅은 이곳에
@@ -10,6 +10,7 @@ const App = () => {
       <Route path='/' element={<CheckLogin />}>
         <Route path='/' element={<CommonLayout />}>
           <Route path='/' element={<MainPage />} />
+          <Route path='/details/:id' element={<DetailPage />} />
         </Route>
         <Route path='/' element={<LoginLayout />}>
           <Route path='/login' element={<LoginPage />} />

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,7 +1,7 @@
 import { Routes, Route } from 'react-router-dom';
 
 import { DetailPage, LoginPage, MainPage, RegisterPage, TestPage } from 'pages';
-import { CheckLogin, LoginLayout, CommonLayout } from 'common';
+import { LoginLayout, CommonLayout } from 'common';
 
 // 라우팅은 이곳에
 const App = () => {

--- a/client/src/common/CommonLayout/NavigationBar.styles.ts
+++ b/client/src/common/CommonLayout/NavigationBar.styles.ts
@@ -11,7 +11,9 @@ export const navigationBarWrapperStyle = css({
   alignItems: 'center',
   justifyContent: 'space-between',
   padding: `${COMMON_SIZE.TITLE_BAR_PADDING_VERTICAL}px ${COMMON_SIZE.TITLE_BAR_PADDING_HORIZONTAL}px`,
+});
 
+export const logoButtonStyle = css({
   '> h1': {
     fontSize: FONT_SIZE.TITLE_48,
     color: COLORS.TEXT_1,
@@ -20,16 +22,9 @@ export const navigationBarWrapperStyle = css({
 });
 
 export const logoutButtonStyle = css({
-  border: 'none',
-  backgroundColor: 'transparent',
-
   '> span': {
     color: COLORS.TEXT_1,
     fontSize: FONT_SIZE.MEDIUM,
     userSelect: 'none',
-  },
-
-  ':hover': {
-    cursor: 'pointer',
   },
 });

--- a/client/src/common/CommonLayout/NavigationBar.tsx
+++ b/client/src/common/CommonLayout/NavigationBar.tsx
@@ -6,7 +6,7 @@ import { useRecoilValue } from 'recoil';
 
 import { currentUserState } from 'store';
 
-import { logoutButtonStyle, navigationBarWrapperStyle } from './NavigationBar.styles';
+import { logoButtonStyle, logoutButtonStyle, navigationBarWrapperStyle } from './NavigationBar.styles';
 
 export const NavigationBar = () => {
   // const [currentUser, setCurrentUser] = useRecoilState(currentUserState);
@@ -19,9 +19,15 @@ export const NavigationBar = () => {
     if (!currentUser.id) navigate('/login');
   }, [currentUser.id]);
 
+  const handleClickLogo = useCallback(() => {
+    navigate('/');
+  }, []);
+
   return (
     <nav css={navigationBarWrapperStyle}>
-      <h1>SCOPA</h1>
+      <button type='button' css={logoButtonStyle} onClick={handleClickLogo}>
+        <h1>SCOPA</h1>
+      </button>
       <button type='button' css={logoutButtonStyle} onClick={handleClickLogin}>
         <span>{currentUser.id ? '로그아웃' : '로그인'}</span>
       </button>

--- a/client/src/common/CommonLayout/styles.ts
+++ b/client/src/common/CommonLayout/styles.ts
@@ -4,7 +4,7 @@ import { COLORS } from 'styles/colors';
 import { COMMON_SIZE } from 'styles/sizes';
 
 export const mainWrapperStyle = css({
-  width: `calc(100% - ${COMMON_SIZE.COMMON_PAGE_PADDING_HORIZONTAL} * 2)`,
+  width: `calc(100% - ${COMMON_SIZE.COMMON_PAGE_PADDING_HORIZONTAL}px * 2)`,
   flex: 1,
   display: 'flex',
   flexDirection: 'column',

--- a/client/src/common/CommonLayout/styles.ts
+++ b/client/src/common/CommonLayout/styles.ts
@@ -6,6 +6,8 @@ import { COMMON_SIZE } from 'styles/sizes';
 export const mainWrapperStyle = css({
   width: `calc(100% - ${COMMON_SIZE.COMMON_PAGE_PADDING_HORIZONTAL} * 2)`,
   flex: 1,
+  display: 'flex',
+  flexDirection: 'column',
   padding: `${COMMON_SIZE.TITLE_BAR_BOTTOM_MARGIN}px ${COMMON_SIZE.COMMON_PAGE_PADDING_HORIZONTAL}px`,
 });
 

--- a/client/src/common/InterestsBox/styles.ts
+++ b/client/src/common/InterestsBox/styles.ts
@@ -14,7 +14,6 @@ export const interestsBoxStyle = css({
   borderRadius: COMMON_SIZE.BORDER_RADIUS,
   border: `5px solid ${COLORS.PRIMARY_1}`,
   '& button': {
-    border: 'none',
     backgroundColor: COLORS.SECONDARY_2,
     fontSize: FONT_SIZE.MEDIUM,
     lineHeight: 3,

--- a/client/src/pages/DetailPage/BottomProfileBox.styles.ts
+++ b/client/src/pages/DetailPage/BottomProfileBox.styles.ts
@@ -12,7 +12,7 @@ export const profileBoxWrapperStyle = css({
 });
 
 export const subtitleStyle = css({
-  fontSize: FONT_SIZE.TITLE_24,
+  fontSize: FONT_SIZE.LARGE,
   fontStyle: 'italic',
   fontWeight: 600,
   marginBottom: COMMON_SIZE.PROFILE_BOX_DD_MARGIN_BOTTOM,

--- a/client/src/pages/DetailPage/BottomProfileBox.styles.ts
+++ b/client/src/pages/DetailPage/BottomProfileBox.styles.ts
@@ -1,0 +1,42 @@
+import { css } from '@emotion/react';
+
+import { COLORS } from 'styles/colors';
+import { COMMON_SIZE, FONT_SIZE } from 'styles/sizes';
+
+export const profileBoxWrapperStyle = css({
+  backgroundColor: COLORS.SECONDARY_1,
+  borderRadius: COMMON_SIZE.BORDER_RADIUS,
+  padding: `${COMMON_SIZE.PROFILE_BOX_PADDING_VERTICAL}px ${COMMON_SIZE.PROFILE_BOX_PADDING_HORIZONTAL}px`,
+  gridRow: '2 / 4',
+  gridColumn: '2',
+});
+
+export const subtitleStyle = css({
+  fontSize: FONT_SIZE.TITLE_24,
+  fontStyle: 'italic',
+  fontWeight: 600,
+  marginBottom: COMMON_SIZE.PROFILE_BOX_DD_MARGIN_BOTTOM,
+  color: COLORS.TEXT_1,
+
+  '::before': {
+    content: `'#'`,
+    marginRight: 10,
+  },
+});
+
+export const DescriptionListStyle = css({
+  display: 'flex',
+  flexDirection: 'column',
+
+  '> dt': {
+    fontSize: FONT_SIZE.MEDIUM,
+    fontWeight: 600,
+    color: COLORS.TEXT_1,
+    marginBottom: COMMON_SIZE.PROFILE_BOX_DT_MARGIN_BOTTOM,
+  },
+
+  '> dd': {
+    color: COLORS.TEXT_1,
+    marginBottom: COMMON_SIZE.PROFILE_BOX_DD_MARGIN_BOTTOM,
+  },
+});

--- a/client/src/pages/DetailPage/BottomProfileBox.tsx
+++ b/client/src/pages/DetailPage/BottomProfileBox.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource @emotion/react */
 
-import { DescriptionListStyle, profileBoxWrapperStyle } from './BottomProfileBox.styles';
+import { DescriptionListStyle, profileBoxWrapperStyle, subtitleStyle } from './BottomProfileBox.styles';
 
 interface Props {
   workType: string;
@@ -12,7 +12,7 @@ interface Props {
 export const BottomProfileBox = ({ workType, workTime, email, requirements }: Props) => {
   return (
     <div css={profileBoxWrapperStyle}>
-      <h3>저는 이런 요구사항이 있어요</h3>
+      <h3 css={subtitleStyle}>저는 이런 요구사항이 있어요</h3>
       <dl css={DescriptionListStyle}>
         <dt>작업 형태</dt>
         <dd>{workType}</dd>

--- a/client/src/pages/DetailPage/BottomProfileBox.tsx
+++ b/client/src/pages/DetailPage/BottomProfileBox.tsx
@@ -1,0 +1,28 @@
+/** @jsxImportSource @emotion/react */
+
+import { DescriptionListStyle, profileBoxWrapperStyle } from './BottomProfileBox.styles';
+
+interface Props {
+  workType: string;
+  workTime: string;
+  email: string;
+  requirements: string[];
+}
+
+export const BottomProfileBox = ({ workType, workTime, email, requirements }: Props) => {
+  return (
+    <div css={profileBoxWrapperStyle}>
+      <h3>저는 이런 요구사항이 있어요</h3>
+      <dl css={DescriptionListStyle}>
+        <dt>작업 형태</dt>
+        <dd>{workType}</dd>
+        <dt>작업 선호 시간대</dt>
+        <dd>{workTime}</dd>
+        <dt>이메일</dt>
+        <dd>{email}</dd>
+        <dt>필수 요구사항</dt>
+        <dd>#{requirements.join(' #')}</dd>
+      </dl>
+    </div>
+  );
+};

--- a/client/src/pages/DetailPage/CodeBox.styles.ts
+++ b/client/src/pages/DetailPage/CodeBox.styles.ts
@@ -5,7 +5,7 @@ import { COMMON_SIZE } from 'styles/sizes';
 
 export const codeBoxWrapperStyle = css({
   backgroundColor: COLORS.TEXT_1,
-  gridRow: '1 / 3',
+  gridRow: '1 / 4',
   gridColumn: '1',
   borderRadius: COMMON_SIZE.BORDER_RADIUS,
   padding: COMMON_SIZE.CODE_BOX_PADDING,

--- a/client/src/pages/DetailPage/CodeBox.styles.ts
+++ b/client/src/pages/DetailPage/CodeBox.styles.ts
@@ -1,0 +1,40 @@
+import { css } from '@emotion/react';
+
+import { COLORS } from 'styles/colors';
+import { COMMON_SIZE } from 'styles/sizes';
+
+export const codeBoxWrapperStyle = css({
+  backgroundColor: COLORS.TEXT_1,
+  gridRow: '1 / 3',
+  gridColumn: '1',
+  borderRadius: COMMON_SIZE.BORDER_RADIUS,
+  padding: COMMON_SIZE.LOGIN_BOX_PADDING / 2,
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'flex-end',
+});
+
+export const codeBoxInnerStyle = css({
+  width: '100%',
+  flex: 1,
+  display: 'grid',
+  gridTemplateColumns: '25px 1fr',
+  gap: 8,
+  overflow: 'scroll',
+});
+
+export const codeNumberStyle = css({
+  display: 'flex',
+  flexDirection: 'column',
+  color: COLORS.TEXT_2,
+});
+
+export const codeBoxStyle = css({
+  color: COLORS.WHITE,
+});
+
+export const languageStyle = css({
+  color: COLORS.WHITE,
+  opacity: 0.5,
+  fontStyle: 'italic',
+});

--- a/client/src/pages/DetailPage/CodeBox.styles.ts
+++ b/client/src/pages/DetailPage/CodeBox.styles.ts
@@ -8,7 +8,7 @@ export const codeBoxWrapperStyle = css({
   gridRow: '1 / 3',
   gridColumn: '1',
   borderRadius: COMMON_SIZE.BORDER_RADIUS,
-  padding: COMMON_SIZE.LOGIN_BOX_PADDING / 2,
+  padding: COMMON_SIZE.CODE_BOX_PADDING,
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'flex-end',

--- a/client/src/pages/DetailPage/CodeBox.tsx
+++ b/client/src/pages/DetailPage/CodeBox.tsx
@@ -12,6 +12,7 @@ interface Props {
 export const CodeBox = ({ code, language }: Props) => {
   const parsedCode = useMemo(() => {
     return code.split('\n').map((str, idx) => (
+      // eslint-disable-next-line react/no-array-index-key
       <code key={`span-${idx}`}>
         {str}
         <br />

--- a/client/src/pages/DetailPage/CodeBox.tsx
+++ b/client/src/pages/DetailPage/CodeBox.tsx
@@ -1,0 +1,36 @@
+/** @jsxImportSource @emotion/react */
+
+import { useMemo } from 'react';
+
+import { codeBoxInnerStyle, codeBoxStyle, codeBoxWrapperStyle, codeNumberStyle, languageStyle } from './CodeBox.styles';
+
+interface Props {
+  code: string;
+  language: string;
+}
+
+export const CodeBox = ({ code, language }: Props) => {
+  const parsedCode = useMemo(() => {
+    return code.split('\n').map((str, idx) => (
+      <code key={`span-${idx}`}>
+        {str}
+        <br />
+      </code>
+    ));
+  }, [code]);
+
+  const codeLineNumber = useMemo(() => {
+    const { length } = code.split('\n');
+    return [...Array(length).keys()].map((v) => <code key={`line-num=${v}`}>{v}</code>);
+  }, [code]);
+
+  return (
+    <div css={codeBoxWrapperStyle}>
+      <div css={codeBoxInnerStyle}>
+        <pre css={codeNumberStyle}>{codeLineNumber}</pre>
+        <pre css={codeBoxStyle}>{parsedCode}</pre>
+      </div>
+      <span css={languageStyle}>using {language}</span>
+    </div>
+  );
+};

--- a/client/src/pages/DetailPage/TopProfileBox.styles.ts
+++ b/client/src/pages/DetailPage/TopProfileBox.styles.ts
@@ -11,7 +11,7 @@ export const profileBoxWrapperStyle = css({
   gridColumn: '2',
 });
 
-export const profileBoxDescriptionListStyle = css({
+export const DescriptionListStyle = css({
   display: 'flex',
   flexDirection: 'column',
 

--- a/client/src/pages/DetailPage/TopProfileBox.styles.ts
+++ b/client/src/pages/DetailPage/TopProfileBox.styles.ts
@@ -1,12 +1,14 @@
 import { css } from '@emotion/react';
 
 import { COLORS } from 'styles/colors';
-import { COMMON_SIZE } from 'styles/sizes';
+import { COMMON_SIZE, FONT_SIZE } from 'styles/sizes';
 
 export const profileBoxWrapperStyle = css({
   backgroundColor: COLORS.PRIMARY_1,
   borderRadius: COMMON_SIZE.BORDER_RADIUS,
-  padding: COMMON_SIZE.PROFILE_BOX_PADDING,
+  padding: `${COMMON_SIZE.PROFILE_BOX_PADDING_VERTICAL}px ${COMMON_SIZE.PROFILE_BOX_PADDING_HORIZONTAL}px`,
+  gridRow: '1',
+  gridColumn: '2',
 });
 
 export const profileBoxDescriptionListStyle = css({
@@ -14,7 +16,7 @@ export const profileBoxDescriptionListStyle = css({
   flexDirection: 'column',
 
   '> dt': {
-    fontSize: 20,
+    fontSize: FONT_SIZE.LARGE,
     fontStyle: 'italic',
     fontWeight: 600,
     color: COLORS.TEXT_1,
@@ -28,6 +30,9 @@ export const profileBoxDescriptionListStyle = css({
 
   '> dd': {
     color: COLORS.TEXT_1,
+  },
+
+  '> dd:nth-child(2)': {
     marginBottom: COMMON_SIZE.PROFILE_BOX_DD_MARGIN_BOTTOM,
   },
 });

--- a/client/src/pages/DetailPage/TopProfileBox.styles.ts
+++ b/client/src/pages/DetailPage/TopProfileBox.styles.ts
@@ -32,7 +32,7 @@ export const DescriptionListStyle = css({
     color: COLORS.TEXT_1,
   },
 
-  '> dd:nth-child(2)': {
+  '> dd:nth-of-type(1)': {
     marginBottom: COMMON_SIZE.PROFILE_BOX_DD_MARGIN_BOTTOM,
   },
 });

--- a/client/src/pages/DetailPage/TopProfileBox.styles.ts
+++ b/client/src/pages/DetailPage/TopProfileBox.styles.ts
@@ -1,0 +1,33 @@
+import { css } from '@emotion/react';
+
+import { COLORS } from 'styles/colors';
+import { COMMON_SIZE } from 'styles/sizes';
+
+export const profileBoxWrapperStyle = css({
+  backgroundColor: COLORS.PRIMARY_1,
+  borderRadius: COMMON_SIZE.BORDER_RADIUS,
+  padding: COMMON_SIZE.PROFILE_BOX_PADDING,
+});
+
+export const profileBoxDescriptionListStyle = css({
+  display: 'flex',
+  flexDirection: 'column',
+
+  '> dt': {
+    fontSize: 20,
+    fontStyle: 'italic',
+    fontWeight: 600,
+    color: COLORS.TEXT_1,
+    marginBottom: COMMON_SIZE.PROFILE_BOX_DT_MARGIN_BOTTOM,
+  },
+
+  '> dt::before': {
+    content: `'#'`,
+    marginRight: 10,
+  },
+
+  '> dd': {
+    color: COLORS.TEXT_1,
+    marginBottom: COMMON_SIZE.PROFILE_BOX_DD_MARGIN_BOTTOM,
+  },
+});

--- a/client/src/pages/DetailPage/TopProfileBox.tsx
+++ b/client/src/pages/DetailPage/TopProfileBox.tsx
@@ -1,0 +1,21 @@
+/** @jsxImportSource @emotion/react */
+
+import { profileBoxDescriptionListStyle, profileBoxWrapperStyle } from './TopProfileBox.styles';
+
+interface Props {
+  interest: string;
+  techStack: string[];
+}
+
+export const TopProfileBox = ({ interest, techStack }: Props) => {
+  return (
+    <div css={profileBoxWrapperStyle}>
+      <dl css={profileBoxDescriptionListStyle}>
+        <dt>저는 이런 분야에 자신있어요</dt>
+        <dd>{interest}</dd>
+        <dt>저는 이런 기술을 사용할 수 있어요</dt>
+        <dd>{techStack.join(', ')}</dd>
+      </dl>
+    </div>
+  );
+};

--- a/client/src/pages/DetailPage/TopProfileBox.tsx
+++ b/client/src/pages/DetailPage/TopProfileBox.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource @emotion/react */
 
-import { profileBoxDescriptionListStyle, profileBoxWrapperStyle } from './TopProfileBox.styles';
+import { DescriptionListStyle, profileBoxWrapperStyle } from './TopProfileBox.styles';
 
 interface Props {
   interest: string;
@@ -10,7 +10,7 @@ interface Props {
 export const TopProfileBox = ({ interest, techStack }: Props) => {
   return (
     <div css={profileBoxWrapperStyle}>
-      <dl css={profileBoxDescriptionListStyle}>
+      <dl css={DescriptionListStyle}>
         <dt>저는 이런 분야에 자신있어요</dt>
         <dd>{interest}</dd>
         <dt>저는 이런 기술을 사용할 수 있어요</dt>

--- a/client/src/pages/DetailPage/index.tsx
+++ b/client/src/pages/DetailPage/index.tsx
@@ -6,6 +6,7 @@ import { MiniNavBar } from 'common';
 
 import { PencilIcon } from 'assets/svgs';
 import { detailProfileWrapperStyle } from './styles';
+import { CodeBox } from './CodeBox';
 
 const MockUpData = {
   code: `export const DetailPage = () => {
@@ -24,6 +25,7 @@ const MockUpData = {
     </div>
   );
 };`,
+  language: 'typescript',
   skills: ['React', 'Emotion', 'Typescript'],
   requirements: ['잠실사는사람만', '소통좋아해요'],
   liked: false,
@@ -43,6 +45,7 @@ export const DetailPage = () => {
         </>
       </MiniNavBar>
       <div css={detailProfileWrapperStyle}>
+        <CodeBox code={MockUpData.code} language={MockUpData.language} />
         <div>어쩌구</div>
         <div>저쩌구</div>
       </div>

--- a/client/src/pages/DetailPage/index.tsx
+++ b/client/src/pages/DetailPage/index.tsx
@@ -1,0 +1,3 @@
+export const DetailPage = () => {
+  return <div>상세페이지임 암튼그럼ㅋㅋ</div>;
+};

--- a/client/src/pages/DetailPage/index.tsx
+++ b/client/src/pages/DetailPage/index.tsx
@@ -8,6 +8,7 @@ import { CodeBox } from './CodeBox';
 import { detailProfileWrapperStyle, editButtonStyle, nicknameSpanStyle } from './styles';
 
 import { PencilIcon } from 'assets/svgs';
+import { TopProfileBox } from './TopProfileBox';
 
 const MockUpData = {
   code: `export const DetailPage = () => {
@@ -27,9 +28,13 @@ const MockUpData = {
   );
 };`,
   language: 'typescript',
+  interest: 'frontend',
   skills: ['React', 'Emotion', 'Typescript'],
   requirements: ['잠실사는사람만', '소통좋아해요'],
   liked: false,
+  worktype: '페어 프로그래밍, 잠실역 근처',
+  worktime: '새벽은 타협 가능하고 오후 1시부터 항상 비어있어요',
+  email: 'earlybird@boostcamp.org',
 };
 
 export const DetailPage = () => {
@@ -47,7 +52,7 @@ export const DetailPage = () => {
       </MiniNavBar>
       <div css={detailProfileWrapperStyle}>
         <CodeBox code={MockUpData.code} language={MockUpData.language} />
-        <div>어쩌구</div>
+        <TopProfileBox interest={MockUpData.interest} techStack={MockUpData.skills} />
         <div>저쩌구</div>
       </div>
     </>

--- a/client/src/pages/DetailPage/index.tsx
+++ b/client/src/pages/DetailPage/index.tsx
@@ -4,12 +4,12 @@ import { useParams } from 'react-router-dom';
 
 import { MiniNavBar } from 'common';
 import { CodeBox } from './CodeBox';
+import { TopProfileBox } from './TopProfileBox';
+import { BottomProfileBox } from './BottomProfileBox';
 
 import { detailProfileWrapperStyle, editButtonStyle, nicknameSpanStyle } from './styles';
 
 import { PencilIcon } from 'assets/svgs';
-import { TopProfileBox } from './TopProfileBox';
-import { BottomProfileBox } from './BottomProfileBox';
 
 const MockUpData = {
   code: `export const DetailPage = () => {

--- a/client/src/pages/DetailPage/index.tsx
+++ b/client/src/pages/DetailPage/index.tsx
@@ -9,6 +9,7 @@ import { detailProfileWrapperStyle, editButtonStyle, nicknameSpanStyle } from '.
 
 import { PencilIcon } from 'assets/svgs';
 import { TopProfileBox } from './TopProfileBox';
+import { BottomProfileBox } from './BottomProfileBox';
 
 const MockUpData = {
   code: `export const DetailPage = () => {
@@ -53,7 +54,12 @@ export const DetailPage = () => {
       <div css={detailProfileWrapperStyle}>
         <CodeBox code={MockUpData.code} language={MockUpData.language} />
         <TopProfileBox interest={MockUpData.interest} techStack={MockUpData.skills} />
-        <div>저쩌구</div>
+        <BottomProfileBox
+          workType={MockUpData.worktype}
+          workTime={MockUpData.worktime}
+          email={MockUpData.email}
+          requirements={MockUpData.requirements}
+        />
       </div>
     </>
   );

--- a/client/src/pages/DetailPage/index.tsx
+++ b/client/src/pages/DetailPage/index.tsx
@@ -1,3 +1,51 @@
+/** @jsxImportSource @emotion/react */
+
+import { useParams } from 'react-router-dom';
+
+import { MiniNavBar } from 'common';
+
+import { PencilIcon } from 'assets/svgs';
+import { detailProfileWrapperStyle } from './styles';
+
+const MockUpData = {
+  code: `export const DetailPage = () => {
+  const { id } = useParams();
+    return (
+    <div>
+      <MiniNavBar>
+        <>
+          <span>{id}</span>
+          <button type='button'>
+            <PencilIcon />
+          </button>
+        </>
+      </MiniNavBar>
+      상세페이지임 암튼그럼ㅋㅋ
+    </div>
+  );
+};`,
+  skills: ['React', 'Emotion', 'Typescript'],
+  requirements: ['잠실사는사람만', '소통좋아해요'],
+  liked: false,
+};
+
 export const DetailPage = () => {
-  return <div>상세페이지임 암튼그럼ㅋㅋ</div>;
+  const { id } = useParams();
+
+  return (
+    <>
+      <MiniNavBar>
+        <>
+          <span>{id}</span>
+          <button type='button'>
+            <PencilIcon />
+          </button>
+        </>
+      </MiniNavBar>
+      <div css={detailProfileWrapperStyle}>
+        <div>어쩌구</div>
+        <div>저쩌구</div>
+      </div>
+    </>
+  );
 };

--- a/client/src/pages/DetailPage/index.tsx
+++ b/client/src/pages/DetailPage/index.tsx
@@ -3,10 +3,11 @@
 import { useParams } from 'react-router-dom';
 
 import { MiniNavBar } from 'common';
+import { CodeBox } from './CodeBox';
+
+import { detailProfileWrapperStyle } from './styles';
 
 import { PencilIcon } from 'assets/svgs';
-import { detailProfileWrapperStyle } from './styles';
-import { CodeBox } from './CodeBox';
 
 const MockUpData = {
   code: `export const DetailPage = () => {

--- a/client/src/pages/DetailPage/index.tsx
+++ b/client/src/pages/DetailPage/index.tsx
@@ -5,7 +5,7 @@ import { useParams } from 'react-router-dom';
 import { MiniNavBar } from 'common';
 import { CodeBox } from './CodeBox';
 
-import { detailProfileWrapperStyle } from './styles';
+import { detailProfileWrapperStyle, editButtonStyle, nicknameSpanStyle } from './styles';
 
 import { PencilIcon } from 'assets/svgs';
 
@@ -39,8 +39,8 @@ export const DetailPage = () => {
     <>
       <MiniNavBar>
         <>
-          <span>{id}</span>
-          <button type='button'>
+          <span css={nicknameSpanStyle}>{id}</span>
+          <button type='button' css={editButtonStyle}>
             <PencilIcon />
           </button>
         </>

--- a/client/src/pages/DetailPage/styles.ts
+++ b/client/src/pages/DetailPage/styles.ts
@@ -1,0 +1,10 @@
+import { css } from '@emotion/react';
+
+import { COMMON_SIZE } from 'styles/sizes';
+
+export const detailProfileWrapperStyle = css({
+  display: 'grid',
+  gridTemplateColumns: 'repeat(2, 1fr)',
+  gridTemplateRows: 'repeat(2, 1fr)',
+  gap: COMMON_SIZE.GRID_GAP,
+});

--- a/client/src/pages/DetailPage/styles.ts
+++ b/client/src/pages/DetailPage/styles.ts
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
-import { COLORS } from 'styles/colors';
 
+import { COLORS } from 'styles/colors';
 import { COMMON_SIZE, FONT_SIZE } from 'styles/sizes';
 
 export const detailProfileWrapperStyle = css({

--- a/client/src/pages/DetailPage/styles.ts
+++ b/client/src/pages/DetailPage/styles.ts
@@ -7,4 +7,7 @@ export const detailProfileWrapperStyle = css({
   gridTemplateColumns: 'repeat(2, 1fr)',
   gridTemplateRows: 'repeat(2, 1fr)',
   gap: COMMON_SIZE.GRID_GAP,
+  flex: 1,
+  paddingLeft: COMMON_SIZE.COMMON_PAGE_PADDING_HORIZONTAL / 2,
+  paddingRight: COMMON_SIZE.COMMON_PAGE_PADDING_HORIZONTAL / 2,
 });

--- a/client/src/pages/DetailPage/styles.ts
+++ b/client/src/pages/DetailPage/styles.ts
@@ -1,12 +1,12 @@
 import { css } from '@emotion/react';
 import { COLORS } from 'styles/colors';
 
-import { COMMON_SIZE } from 'styles/sizes';
+import { COMMON_SIZE, FONT_SIZE } from 'styles/sizes';
 
 export const detailProfileWrapperStyle = css({
   display: 'grid',
   gridTemplateColumns: 'repeat(2, 1fr)',
-  gridTemplateRows: 'repeat(2, 1fr)',
+  gridTemplateRows: 'repeat(3, 1fr)',
   gap: COMMON_SIZE.GRID_GAP,
   flex: 1,
   paddingLeft: COMMON_SIZE.COMMON_PAGE_PADDING_HORIZONTAL / 2,
@@ -16,7 +16,7 @@ export const detailProfileWrapperStyle = css({
 export const nicknameSpanStyle = css({
   color: COLORS.TEXT_1,
   fontWeight: 700,
-  fontSize: 18,
+  fontSize: FONT_SIZE.LARGE,
 });
 
 export const editButtonStyle = css({

--- a/client/src/pages/DetailPage/styles.ts
+++ b/client/src/pages/DetailPage/styles.ts
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { COLORS } from 'styles/colors';
 
 import { COMMON_SIZE } from 'styles/sizes';
 
@@ -10,4 +11,24 @@ export const detailProfileWrapperStyle = css({
   flex: 1,
   paddingLeft: COMMON_SIZE.COMMON_PAGE_PADDING_HORIZONTAL / 2,
   paddingRight: COMMON_SIZE.COMMON_PAGE_PADDING_HORIZONTAL / 2,
+});
+
+export const nicknameSpanStyle = css({
+  color: COLORS.TEXT_1,
+  fontWeight: 700,
+  fontSize: 18,
+});
+
+export const editButtonStyle = css({
+  border: 'none',
+  background: 'none',
+
+  '> svg': {
+    width: COMMON_SIZE.SELECT_BOX_HEIGHT,
+    height: COMMON_SIZE.SELECT_BOX_HEIGHT,
+  },
+
+  ':hover': {
+    cursor: 'pointer',
+  },
 });

--- a/client/src/pages/DetailPage/styles.ts
+++ b/client/src/pages/DetailPage/styles.ts
@@ -20,15 +20,8 @@ export const nicknameSpanStyle = css({
 });
 
 export const editButtonStyle = css({
-  border: 'none',
-  background: 'none',
-
   '> svg': {
     width: COMMON_SIZE.SELECT_BOX_HEIGHT,
     height: COMMON_SIZE.SELECT_BOX_HEIGHT,
-  },
-
-  ':hover': {
-    cursor: 'pointer',
   },
 });

--- a/client/src/pages/MainPage/index.tsx
+++ b/client/src/pages/MainPage/index.tsx
@@ -1,4 +1,5 @@
 import { MiniNavBar } from 'common';
+import { Link } from 'react-router-dom';
 
 export const MainPage = () => {
   // MiniNavBar 사용례: 저렇게 투명 태그로 감싸 넣어야 space-between 잘 반영 됩니다
@@ -10,7 +11,9 @@ export const MainPage = () => {
           <button type='button'>버튼</button>
         </>
       </MiniNavBar>
-      <div>내용내용내용</div>
+      <div>
+        <Link to='/detail/4242'>상세페이지 링크</Link>
+      </div>
     </>
   );
 };

--- a/client/src/pages/MainPage/index.tsx
+++ b/client/src/pages/MainPage/index.tsx
@@ -1,5 +1,6 @@
-import { MiniNavBar } from 'common';
 import { Link } from 'react-router-dom';
+
+import { MiniNavBar } from 'common';
 
 export const MainPage = () => {
   // MiniNavBar 사용례: 저렇게 투명 태그로 감싸 넣어야 space-between 잘 반영 됩니다

--- a/client/src/pages/RegisterPage/SelectedItems.tsx
+++ b/client/src/pages/RegisterPage/SelectedItems.tsx
@@ -14,14 +14,14 @@ interface Props {
 export const SelectedItems = ({ itemNames, setItems }: Props) => {
   const handleClick = useCallback(
     (itemName: string) => {
-      setItems(itemNames.filter((name) => name != itemName));
+      setItems(itemNames.filter((name) => name !== itemName));
     },
     [itemNames]
   );
 
   return (
     <div css={registerPageSelectedItemsStyle}>
-      {itemNames.map((itemName, i) => (
+      {itemNames.map((itemName) => (
         <div key={`techStack-${itemName}`} css={registerPageSelectedItemStyle}>
           <span>{itemName}</span>
           <button

--- a/client/src/pages/RegisterPage/SelectedItems.tsx
+++ b/client/src/pages/RegisterPage/SelectedItems.tsx
@@ -2,12 +2,9 @@
 
 import { Dispatch, SetStateAction, useCallback } from 'react';
 
-import {
-  registerPageSelectedItemButtonStyle,
-  registerPageSelectedItemsStyle,
-  registerPageSelectedItemStyle,
-} from './styles';
-import { XIcon } from '../../assets/svgs';
+import { registerPageSelectedItemsStyle, registerPageSelectedItemStyle } from './styles';
+
+import { XIcon } from 'assets/svgs';
 
 interface Props {
   itemNames: Array<string>;
@@ -29,7 +26,6 @@ export const SelectedItems = ({ itemNames, setItems }: Props) => {
           <span>{itemName}</span>
           <button
             type='button'
-            css={registerPageSelectedItemButtonStyle}
             onClick={() => {
               handleClick(itemName);
             }}

--- a/client/src/pages/RegisterPage/styles.ts
+++ b/client/src/pages/RegisterPage/styles.ts
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
+
 import { COLORS } from 'styles/colors';
 import { COMMON_SIZE, FONT_SIZE } from 'styles/sizes';
-import exp from 'constants';
 
 export const registerPageInnerStyle = css({
   display: 'grid',

--- a/client/src/pages/RegisterPage/styles.ts
+++ b/client/src/pages/RegisterPage/styles.ts
@@ -47,13 +47,11 @@ export const registerPageIdButtonStyle = css({
   backgroundColor: COLORS.PRIMARY_2,
   color: COLORS.SECONDARY_2,
   fontSize: FONT_SIZE.LARGE,
-  border: 'none',
   width: 100,
 });
 
 export const registerInputArrowButtonStyle = css({
   backgroundColor: COLORS.PRIMARY_2,
-  border: 'none',
   display: 'flex',
   justifyItems: 'center',
   alignItems: 'center',
@@ -63,7 +61,6 @@ export const registerPageButtonStyle = (isAllSet: boolean) =>
   css({
     backgroundColor: COLORS.PRIMARY_2,
     fontSize: FONT_SIZE.LARGE,
-    border: 'none',
     fontWeight: 'bold',
     width: 400,
     height: 70,
@@ -80,11 +77,6 @@ export const registerPageSelectedItemsStyle = css({
 export const registerPageSelectedItemStyle = css({
   display: 'flex',
   alignItems: 'center',
-});
-
-export const registerPageSelectedItemButtonStyle = css({
-  border: 'none',
-  backgroundColor: 'transparent',
 });
 
 export const idValidationWarningStyle = css({

--- a/client/src/pages/index.ts
+++ b/client/src/pages/index.ts
@@ -1,4 +1,5 @@
 export { MainPage } from './MainPage';
+export { DetailPage } from './DetailPage';
 
 export { LoginPage } from './LoginPage';
 export { RegisterPage } from './RegisterPage';

--- a/client/src/reset.css
+++ b/client/src/reset.css
@@ -171,3 +171,12 @@ div[id='root'] {
   display: flex;
   flex-direction: column;
 }
+
+button {
+  background: none;
+  border: none;
+}
+
+button:hover {
+  cursor: pointer;
+}

--- a/client/src/styles/sizes.ts
+++ b/client/src/styles/sizes.ts
@@ -29,7 +29,7 @@ export const COMMON_SIZE = {
   SEARCH_BAR_BORDER_RADIUS: 30, // 검색 바 모서리 둥글기
   SEARCH_BAR_BOTTOM_MARGIN: 30, // 검색 바 하단 Margin
 
-  SELECT_BOX_PADDING_VERTICAL: 15, // 검색 바 내부 선택버튼 Padding 위아래
+  SELECT_BOX_HEIGHT: 30, // 검색 바 내부 선택버튼 높이 (높이를 고정시켜야 디테일 페이지에서도 같이 사용가능)
   SELECT_BOX_PADDING_HORIZONTAL: 25, // 검색 바 내부 선택버튼 Padding 좌우
 
   POPOVER_BORDER: 5, // 리스트 테두리

--- a/client/src/styles/sizes.ts
+++ b/client/src/styles/sizes.ts
@@ -20,7 +20,7 @@ export const COMMON_SIZE = {
 
   PROFILE_ITEM_PADDING: 15, // 메인 페이지 프로필 리스트 내부 컴포넌트 Padding 상하좌우
 
-  TITLE_BAR_PADDING_VERTICAL: 30, // 최상단 타이틀바 Padding 상하
+  TITLE_BAR_PADDING_VERTICAL: 20, // 최상단 타이틀바 Padding 상하
   TITLE_BAR_PADDING_HORIZONTAL: 50, // 최상단 타이틀바 Padding 좌우
   TITLE_BAR_BOTTOM_MARGIN: 20, // 최상단 타이틀바 하단 Margin
 
@@ -43,7 +43,8 @@ export const COMMON_SIZE = {
 
   COMMON_PAGE_PADDING_HORIZONTAL: 60, // 로그인, 회원가입 페이지 제외 나머지 페이지의 좌우 여백
 
-  PROFILE_BOX_PADDING: 40,
+  PROFILE_BOX_PADDING_HORIZONTAL: 40,
+  PROFILE_BOX_PADDING_VERTICAL: 20,
   CODE_BOX_PADDING: 20,
   PROFILE_BOX_DT_MARGIN_BOTTOM: 10,
   PROFILE_BOX_DD_MARGIN_BOTTOM: 20,

--- a/client/src/styles/sizes.ts
+++ b/client/src/styles/sizes.ts
@@ -43,5 +43,10 @@ export const COMMON_SIZE = {
 
   COMMON_PAGE_PADDING_HORIZONTAL: 60, // 로그인, 회원가입 페이지 제외 나머지 페이지의 좌우 여백
 
+  PROFILE_BOX_PADDING: 40,
+  CODE_BOX_PADDING: 20,
+  PROFILE_BOX_DT_MARGIN_BOTTOM: 10,
+  PROFILE_BOX_DD_MARGIN_BOTTOM: 20,
+
   GRID_GAP: 30, // display: grid 사용하는 부분 (상세 프로필 페이지, 메인화면 프로필 리스트) 에서 갭 크기
 };

--- a/client/src/styles/sizes.ts
+++ b/client/src/styles/sizes.ts
@@ -43,5 +43,5 @@ export const COMMON_SIZE = {
 
   COMMON_PAGE_PADDING_HORIZONTAL: 60, // 로그인, 회원가입 페이지 제외 나머지 페이지의 좌우 여백
 
-  GRID_GAP: 50, // display: grid 사용하는 부분 (상세 프로필 페이지, 메인화면 프로필 리스트) 에서 갭 크기
+  GRID_GAP: 30, // display: grid 사용하는 부분 (상세 프로필 페이지, 메인화면 프로필 리스트) 에서 갭 크기
 };


### PR DESCRIPTION
## 📕 FE. 상세 페이지 레이아웃 잡기

관련이슈 #29 

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

![image](https://user-images.githubusercontent.com/37893979/202497681-b1693fdd-3dff-4acd-86b4-be395b995656.png)

- [x] `/detail/[id]` 에 라우팅 걸어둠
  - `[id]` 를 useParams로 받아와서 서로 다른 유저를 띄워줄 계획
- [x] 상단바 레이아웃 가져다 사용
  -  #28 에서 작성한 레이아웃을 가져오기
- [x] 아이디 및 편집 버튼 있는 바 레이아웃 작성
  -  #28 에서 작성한 컴포넌트를 가져오기
- [x] 리스트 내부 요소 각각에 해당하는 컴포넌트 레이아웃 잡기
  - css grid 이용하여 칸 배분 및 구성
  - 내용물은 하드코딩으로 작성
  - 편집 기능 같은 건 아직 만들지 않기
  - 코드 박스, 상단 프로필 박스, 하단 프로필 박스로 구성되어 있음
- [x] reset.css에 버튼 스타일 리셋하는 코드 추가
  - 기존에 emotion 스타일시트에 추가했던 버튼 스타일 리셋 코드 (`border: 'none'`, `background: none`) 중복코드이므로 전부 삭제
- [x] 상단바 로고 클릭하면 메인페이지로 이동 기능 추가

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- CSS가 대부분이라 리뷰를 할만한 게 그렇게 많지는 않은 듯 합니다
- 한번씩 돌려 보시고 보기에 이상이 없는지 체크하면 좋을 것 같습니다
- 아니면 컨벤션 관련 실수한 게 있다면 알려주세욤
