### PR TITLE
[Feat] 회원 삭제 api 및 회원 아이디 중복 로직 추가

### DIFF
--- a/server/src/auth/auth.controller.ts
+++ b/server/src/auth/auth.controller.ts
@@ -5,10 +5,14 @@ import { UserInfo } from 'src/d';
 import { AuthService } from './auth.service';
 import { errors } from '../common/response/error-response';
 import { SuccessResponse } from '../common/response/success-response';
+import { UserService } from 'src/user/user.service';
 
 @Controller('/api/auth')
 export class AuthController {
-  constructor(private readonly authService: AuthService) {}
+  constructor(
+    private readonly authService: AuthService,
+    private readonly userService: UserService,
+  ) {}
 
   @Get('/google-callback')
   async GoogleCallback(
@@ -16,17 +20,23 @@ export class AuthController {
     @Req() req: Request,
     @Res() res: Response,
   ) {
-    const user: UserInfo = await this.authService.getGoogleInfo(code);
+    const userInfo: UserInfo = await this.authService.getGoogleInfo(code);
 
     //세션에 사용자 정보 저장
     const session = req.session;
-    session.user = user;
+    session.user = userInfo;
 
     //DB에서 유저 확인
-    //없으면 회원가입으로 redirect
-    //있으면 메인으로 redirect
+    const user = this.userService.findOne(
+      userInfo.authProvider,
+      userInfo.authId,
+    );
 
-    return res.status(200).redirect(`${process.env.CLIENT_URL}/register`);
+    if (!user) {
+      res.status(200).redirect(`${process.env.CLIENT_URL}/register`);
+    }
+
+    return res.status(200).redirect(`${process.env.CLIENT_URL}`);
   }
 
   @Get('/github-callback')
@@ -35,17 +45,23 @@ export class AuthController {
     @Req() req: Request,
     @Res() res: Response,
   ) {
-    const user: UserInfo = await this.authService.getGithubInfo(code);
+    const userInfo: UserInfo = await this.authService.getGithubInfo(code);
 
     //세션에 사용자 정보 저장
     const session = req.session;
-    session.user = user;
+    session.user = userInfo;
 
     //DB에서 유저 확인
-    //없으면 회원가입으로 redirect
-    //있으면 메인으로 redirect
+    const user = this.userService.findOne(
+      userInfo.authProvider,
+      userInfo.authId,
+    );
 
-    return res.status(200).redirect(`${process.env.CLIENT_URL}/register`);
+    if (!user) {
+      res.status(200).redirect(`${process.env.CLIENT_URL}/register`);
+    }
+
+    return res.status(200).redirect(`${process.env.CLIENT_URL}`);
   }
 
   @Get('/check')

--- a/server/src/auth/auth.controller.ts
+++ b/server/src/auth/auth.controller.ts
@@ -53,7 +53,7 @@ export class AuthController {
     if (!session.user) {
       return res.status(401).send({
         code: 20003,
-        message: '로그인 상태가 아닙니다.',
+        message: '로그인 상태가 아닙니다',
       });
     }
 

--- a/server/src/common/response/error-response.ts
+++ b/server/src/common/response/error-response.ts
@@ -37,4 +37,9 @@ export const errors: { readonly [key: string]: ErrorInfo } = {
     '유효하지 않은 authorization code입니다.',
     HttpStatus.UNAUTHORIZED,
   ],
+  NOT_MATCHED_USER: [
+    20006,
+    '일치하는 유저 정보가 없습니다.',
+    HttpStatus.UNAUTHORIZED,
+  ],
 };

--- a/server/src/user/dto/create-user.dto.ts
+++ b/server/src/user/dto/create-user.dto.ts
@@ -1,6 +1,6 @@
-import { IsArray, IsString } from 'class-validator';
+import { IsArray, IsEmail, IsString } from 'class-validator';
 
-export class CreateUserDto {
+export class RequestUserDto {
   @IsString()
   username: string;
 
@@ -9,4 +9,18 @@ export class CreateUserDto {
 
   @IsArray()
   techStack: string[];
+}
+
+export class CreateUserDto {
+  @IsString()
+  authProvider: string;
+
+  @IsString()
+  authId: string;
+
+  @IsEmail()
+  email: string;
+
+  @IsString()
+  username: string;
 }

--- a/server/src/user/dto/create-user.dto.ts
+++ b/server/src/user/dto/create-user.dto.ts
@@ -1,6 +1,6 @@
 import { IsArray, IsEmail, IsString } from 'class-validator';
 
-export class RequestUserDto {
+export class CreateUserRequestDto {
   @IsString()
   username: string;
 

--- a/server/src/user/entities/user.entity.ts
+++ b/server/src/user/entities/user.entity.ts
@@ -48,7 +48,7 @@ export class User extends Document {
   workTime: string;
 
   @Prop()
-  requirement: string;
+  requirements: string[];
 }
 
 export const userSchema = SchemaFactory.createForClass(User);

--- a/server/src/user/entities/user.entity.ts
+++ b/server/src/user/entities/user.entity.ts
@@ -28,6 +28,27 @@ export class User extends Document {
     unique: true,
   })
   username: string;
+
+  @Prop()
+  field: string;
+
+  @Prop()
+  stack: string;
+
+  @Prop()
+  priorityStack: string;
+
+  @Prop()
+  code: string;
+
+  @Prop()
+  workPattern: string;
+
+  @Prop()
+  workTime: string;
+
+  @Prop()
+  requirement: string;
 }
 
 export const userSchema = SchemaFactory.createForClass(User);

--- a/server/src/user/entities/user.entity.ts
+++ b/server/src/user/entities/user.entity.ts
@@ -33,7 +33,7 @@ export class User extends Document {
   interest: string;
 
   @Prop()
-  techStack: string;
+  techStack: string[];
 
   @Prop()
   priorityStack: string;

--- a/server/src/user/entities/user.entity.ts
+++ b/server/src/user/entities/user.entity.ts
@@ -30,10 +30,10 @@ export class User extends Document {
   username: string;
 
   @Prop()
-  field: string;
+  interest: string;
 
   @Prop()
-  stack: string;
+  techStack: string;
 
   @Prop()
   priorityStack: string;

--- a/server/src/user/user.controller.ts
+++ b/server/src/user/user.controller.ts
@@ -12,7 +12,8 @@ import {
 import { Request, Response } from 'express';
 
 import { UserService } from './user.service';
-import { CreateUserDto } from './dto/create-user.dto';
+import { RequestUserDto } from './dto/create-user.dto';
+import { UserInfo } from 'src/d';
 
 @Controller('/api/user')
 export class UserController {
@@ -21,7 +22,7 @@ export class UserController {
   // 회원가입
   @Post('/register')
   async create(
-    @Body() userDto: CreateUserDto,
+    @Body() userDto: RequestUserDto,
     @Req() req: Request,
     @Res() res: Response,
   ) {
@@ -38,7 +39,7 @@ export class UserController {
 
     return res.status(200).send({
       code: 10000,
-      message: '성공.',
+      message: '성공',
     });
   }
 
@@ -76,7 +77,21 @@ export class UserController {
     // 응답
     return res.status(200).send({
       code: 10000,
-      message: '성공.',
+      message: '성공',
+    });
+  }
+
+  // 회원 탈퇴
+  @Delete('/withdraw')
+  withdraw(@Req() req: Request, @Res() res: Response) {
+    const userInfo: UserInfo = req.session.user;
+
+    this.userService.remove(userInfo);
+
+    // 응답
+    return res.status(200).send({
+      code: 10000,
+      message: '성공',
     });
   }
 }

--- a/server/src/user/user.controller.ts
+++ b/server/src/user/user.controller.ts
@@ -27,8 +27,11 @@ export class UserController {
     @Req() req: Request,
     @Res() res: Response,
   ) {
-    const userInfo = req.session.user;
+    if (!req.session.user) {
+      throw errors.NOT_LOGGED_IN;
+    }
 
+    const userInfo = req.session.user;
     const createdUser = await this.userService.create(userDto, userInfo);
 
     if (!createdUser) {
@@ -53,13 +56,7 @@ export class UserController {
   @Get('/validate')
   validateRegisterId(@Query('id') id: string, @Res() res: Response) {
     // 유효성 검사
-    const regexEngNum = /^[a-zA-Z0-9]*$/;
-    const isValidLength = id.length >= 4 && id.length <= 15;
-    const isValidCharacter = regexEngNum.test(id);
-
-    if (!(isValidLength && isValidCharacter)) {
-      throw errors.INVALID_ID;
-    }
+    this.userService.validateUsername(id);
 
     // 중복 확인
     const isDuplicated = false; // DB 설정이 완료되면 실제 중복을 체크하는 로직을 추가해야 합니다.

--- a/server/src/user/user.controller.ts
+++ b/server/src/user/user.controller.ts
@@ -72,14 +72,14 @@ export class UserController {
   // 회원 탈퇴
   @Delete('/withdraw')
   withdraw(@Req() req: Request, @Res() res: Response) {
+    if (!req.session.user) {
+      throw errors.NOT_LOGGED_IN;
+    }
+
     const userInfo: UserInfo = req.session.user;
 
     this.userService.remove(userInfo);
 
-    // 응답
-    return res.status(200).send({
-      code: 10000,
-      message: '성공',
-    });
+    return res.status(200).send(new SuccessResponse());
   }
 }

--- a/server/src/user/user.controller.ts
+++ b/server/src/user/user.controller.ts
@@ -59,11 +59,7 @@ export class UserController {
     this.userService.validateUsername(id);
 
     // 중복 확인
-    const isDuplicated = false; // DB 설정이 완료되면 실제 중복을 체크하는 로직을 추가해야 합니다.
-
-    if (isDuplicated) {
-      throw errors.ID_DUPLICATED;
-    }
+    this.userService.checkDuplicatedUsername(id);
 
     // 응답
     return res.status(200).send(new SuccessResponse());

--- a/server/src/user/user.controller.ts
+++ b/server/src/user/user.controller.ts
@@ -45,8 +45,13 @@ export class UserController {
 
   // 전체 유저 조회
   @Get()
-  findAll() {
-    return this.userService.findAll();
+  findAll(@Req() req: Request) {
+    // return this.userService.findAll();
+
+    const authProvider: string = req.query.authProvider as string;
+    const authId: string = req.query.authId as string;
+
+    return this.userService.findOne(authProvider, authId);
   }
 
   // 아이디 유효성 & 중복 조회

--- a/server/src/user/user.controller.ts
+++ b/server/src/user/user.controller.ts
@@ -12,18 +12,18 @@ import { Request, Response } from 'express';
 
 import { UserService } from './user.service';
 import { UserInfo } from 'src/d';
-import { RequestUserDto } from './dto/create-user.dto';
+import { CreateUserRequestDto } from './dto/create-user.dto';
 import { errors } from '../common/response/error-response';
 import { SuccessResponse } from '../common/response/success-response';
 
-@Controller('/api/user')
+@Controller('/api/users')
 export class UserController {
   constructor(private readonly userService: UserService) {}
 
   // 회원가입
   @Post('/register')
   async create(
-    @Body() userDto: RequestUserDto,
+    @Body() userDto: CreateUserRequestDto,
     @Req() req: Request,
     @Res() res: Response,
   ) {
@@ -44,12 +44,7 @@ export class UserController {
   // 전체 유저 조회
   @Get()
   findAll(@Req() req: Request) {
-    // return this.userService.findAll();
-
-    const authProvider: string = req.query.authProvider as string;
-    const authId: string = req.query.authId as string;
-
-    return this.userService.findOne(authProvider, authId);
+    return this.userService.findAll();
   }
 
   // 아이디 유효성 & 중복 조회

--- a/server/src/user/user.module.ts
+++ b/server/src/user/user.module.ts
@@ -4,12 +4,13 @@ import { MongooseModule } from '@nestjs/mongoose';
 import { UserService } from './user.service';
 import { UserController } from './user.controller';
 import { User, userSchema } from './entities/user.entity';
+import { UserRepository } from './user.repository';
 
 @Module({
   imports: [
     MongooseModule.forFeature([{ name: User.name, schema: userSchema }]),
   ],
   controllers: [UserController],
-  providers: [UserService],
+  providers: [UserService, UserRepository],
 })
 export class UserModule {}

--- a/server/src/user/user.repository.ts
+++ b/server/src/user/user.repository.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
+
 import { CreateUserDto } from './dto/create-user.dto';
 import { User } from './entities/user.entity';
 

--- a/server/src/user/user.repository.ts
+++ b/server/src/user/user.repository.ts
@@ -15,4 +15,11 @@ export class UserRepository {
   async findAll() {
     return await this.userModel.find().exec();
   }
+
+  async findUserByAuthProviderAndAuthId(authProvider: string, authId: string) {
+    return await this.userModel
+      .find()
+      .and([{ authProvider: authProvider }, { authId: authId }])
+      .exec();
+  }
 }

--- a/server/src/user/user.repository.ts
+++ b/server/src/user/user.repository.ts
@@ -23,6 +23,10 @@ export class UserRepository {
       .exec();
   }
 
+  async findUserByUsername(username: string) {
+    return await this.userModel.findOne().where('username').equals(username);
+  }
+
   async delete(user: User) {
     return await this.userModel.deleteOne({ id: user.id });
   }

--- a/server/src/user/user.repository.ts
+++ b/server/src/user/user.repository.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { CreateUserDto } from './dto/create-user.dto';
+import { User } from './entities/user.entity';
+
+@Injectable()
+export class UserRepository {
+  constructor(@InjectModel(User.name) private userModel: Model<User>) {}
+
+  async create(user: CreateUserDto) {
+    return await this.userModel.create(user);
+  }
+
+  async findAll() {
+    return await this.userModel.find().exec();
+  }
+}

--- a/server/src/user/user.repository.ts
+++ b/server/src/user/user.repository.ts
@@ -18,8 +18,12 @@ export class UserRepository {
 
   async findUserByAuthProviderAndAuthId(authProvider: string, authId: string) {
     return await this.userModel
-      .find()
+      .findOne()
       .and([{ authProvider: authProvider }, { authId: authId }])
       .exec();
+  }
+
+  async delete(user: User) {
+    return await this.userModel.deleteOne({ id: user.id });
   }
 }

--- a/server/src/user/user.service.ts
+++ b/server/src/user/user.service.ts
@@ -52,7 +52,7 @@ export class UserService {
     return this.userRepository.delete(user);
   }
 
-  validateUsername(username: string): Boolean {
+  validateUsername(username: string) {
     const regexEngNum = /^[a-zA-Z0-9]*$/;
     const isValidLength = username.length >= 4 && username.length <= 15;
     const isValidCharacter = regexEngNum.test(username);
@@ -60,7 +60,13 @@ export class UserService {
     if (!(isValidLength && isValidCharacter)) {
       throw errors.INVALID_ID;
     }
+  }
 
-    return true;
+  checkDuplicatedUsername(username: string) {
+    const user = this.userRepository.findUserByUsername(username);
+
+    if (user) {
+      throw errors.ID_DUPLICATED;
+    }
   }
 }

--- a/server/src/user/user.service.ts
+++ b/server/src/user/user.service.ts
@@ -45,12 +45,11 @@ export class UserService {
 
     // 불일치 -> 에러 반환
     if (!user) {
-      throw new HttpException('일치하는 유저 정보가 없습니다', 401);
+      throw errors.NOT_MATCHED_USER;
     }
 
     // 일치 -> 유저 정보 삭제 -> 결과 반환
-
-    return true;
+    return this.userRepository.delete(user);
   }
 
   validateUsername(username: string): Boolean {

--- a/server/src/user/user.service.ts
+++ b/server/src/user/user.service.ts
@@ -1,11 +1,10 @@
 import { HttpException, Injectable } from '@nestjs/common';
-import { InjectModel } from '@nestjs/mongoose';
-import { Model } from 'mongoose';
 
 import { RequestUserDto } from './dto/create-user.dto';
 import { User } from './entities/user.entity';
 import { UserInfo } from 'src/d';
 import { UserRepository } from './user.repository';
+import { errors } from 'src/common/response/error-response';
 
 @Injectable()
 export class UserService {
@@ -13,9 +12,12 @@ export class UserService {
 
   // 유저 생성
   async create(userDto: RequestUserDto, userInfo: UserInfo): Promise<User> {
+    // 유효성 검사
+    this.validateUsername(userDto.username);
+
     return await this.userRepository.create({
       ...userInfo,
-      username: userDto.username,
+      ...userDto,
     });
   }
 
@@ -47,6 +49,18 @@ export class UserService {
     }
 
     // 일치 -> 유저 정보 삭제 -> 결과 반환
+
+    return true;
+  }
+
+  validateUsername(username: string): Boolean {
+    const regexEngNum = /^[a-zA-Z0-9]*$/;
+    const isValidLength = username.length >= 4 && username.length <= 15;
+    const isValidCharacter = regexEngNum.test(username);
+
+    if (!(isValidLength && isValidCharacter)) {
+      throw errors.INVALID_ID;
+    }
 
     return true;
   }

--- a/server/src/user/user.service.ts
+++ b/server/src/user/user.service.ts
@@ -1,6 +1,6 @@
 import { HttpException, Injectable } from '@nestjs/common';
 
-import { RequestUserDto } from './dto/create-user.dto';
+import { CreateUserRequestDto } from './dto/create-user.dto';
 import { User } from './entities/user.entity';
 import { UserInfo } from 'src/d';
 import { UserRepository } from './user.repository';
@@ -11,7 +11,10 @@ export class UserService {
   constructor(private readonly userRepository: UserRepository) {}
 
   // 유저 생성
-  async create(userDto: RequestUserDto, userInfo: UserInfo): Promise<User> {
+  async create(
+    userDto: CreateUserRequestDto,
+    userInfo: UserInfo,
+  ): Promise<User> {
     // 유효성 검사
     this.validateUsername(userDto.username);
 

--- a/server/src/user/user.service.ts
+++ b/server/src/user/user.service.ts
@@ -2,34 +2,36 @@ import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 
-import { CreateUserDto } from './dto/create-user.dto';
+import { RequestUserDto } from './dto/create-user.dto';
 import { User } from './entities/user.entity';
 import { UserInfo } from 'src/d';
+import { UserRepository } from './user.repository';
 
 @Injectable()
 export class UserService {
-  constructor(@InjectModel(User.name) private userModel: Model<User>) {}
+  constructor(private readonly userRepository: UserRepository) {}
 
   // 유저 생성
-  async create(userDto: CreateUserDto, userInfo: UserInfo): Promise<User> {
-    const createdUser = new this.userModel({
+  async create(userDto: RequestUserDto, userInfo: UserInfo): Promise<User> {
+    return await this.userRepository.create({
       ...userInfo,
       username: userDto.username,
     });
-
-    return createdUser.save();
   }
 
   // 유저 전체 조회
   async findAll(): Promise<User[]> {
-    return this.userModel.find().exec();
+    return await this.userRepository.findAll();
   }
 
-  findOne(id: number) {
-    return `This action returns a #${id} user`;
-  }
+  // 유저 삭제
+  async remove(userInfo: UserInfo) {
+    // 요청받은 유저 정보가 DB 정보와 일치하는 지 확인하기
 
-  remove(id: number) {
-    return `This action removes a #${id} user`;
+    // 불일치 -> 에러 반환
+
+    // 일치 -> 유저 정보 삭제 -> 결과 반환
+
+    return;
   }
 }

--- a/server/src/user/user.service.ts
+++ b/server/src/user/user.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { HttpException, Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 
@@ -24,14 +24,30 @@ export class UserService {
     return await this.userRepository.findAll();
   }
 
+  async findOne(authProvider: string, authId: string) {
+    return await this.userRepository.findUserByAuthProviderAndAuthId(
+      authProvider,
+      authId,
+    );
+  }
+
   // 유저 삭제
   async remove(userInfo: UserInfo) {
     // 요청받은 유저 정보가 DB 정보와 일치하는 지 확인하기
+    const { authProvider, authId, email } = { ...userInfo };
+
+    const user = await this.userRepository.findUserByAuthProviderAndAuthId(
+      authProvider,
+      authId,
+    );
 
     // 불일치 -> 에러 반환
+    if (!user) {
+      throw new HttpException('일치하는 유저 정보가 없습니다', 401);
+    }
 
     // 일치 -> 유저 정보 삭제 -> 결과 반환
 
-    return;
+    return true;
   }
 }


### PR DESCRIPTION
## 📕 제목

- https://github.com/boostcampwm-2022/web25-SCOPA/issues/3 의 7번 task
- https://github.com/boostcampwm-2022/web25-SCOPA/issues/7 의 7번 task
- https://github.com/boostcampwm-2022/web25-SCOPA/issues/52

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 해당 사용자가 이미 회원가입을 완료한 사용자인지 확인하기(DB), Github, Google 둘 다
   - 회원가입을 이미 한 사용자 -> 메인 페이지로 리다이렉트
   - 회원가입을 하지 않은 사용자 -> 회원가입 페이지로 리다이렉트
- [x] UserRepository 구현
   - UserRepository 를 구현함으로써, service 층에서 직접 DB 에 접근하던 로직을 repository 에게 위임도록 했습니다.
- [x] `api/user/withdraw` API 구현
   - [x] session 에 user 정보 존재 확인
   - [x] 쿠키로 받아온 사용자 정보가 올바른 지 확인을 위한 `userRepository.findUserByAuthProviderAndAuthId` 구현
      - 쿠키에 담긴 `authProvider` 값과 `authId` 값으로 DB 에 사용자가 존재하는 지 확인하기 위하여, 해당 값으로 user 데이터를 조회하는 함수입니다.
   - [x] 불일치하다면 에러를 반환합니다.
   - [x] 일치한다면 해당 유저를 삭제하고 결과를 반환합니다. 
- [x] `api/user/validate` 아이디 중복을 체크하는 로직 추가
   - [x] username 이 일치하는 user 가 존재한다면 에러 반환

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- `user.controller.ts` 와 `user.service.ts` 의 `findAll()` 메소드는 기능 테스트를 위한 메소드로 활용하고 있어서 빼고 봐주시면 됩니다.
