### PR TITLE
[Feat] 좋아요 관련 api 구현

### DIFF
--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -4,6 +4,8 @@ import { MongooseModule } from '@nestjs/mongoose';
 
 import { AuthModule } from './auth/auth.module';
 import { UserModule } from './user/user.module';
+import { LikeModule } from './like/like.module';
+import { TestModule } from './test/test.module';
 
 @Module({
   imports: [
@@ -16,6 +18,8 @@ import { UserModule } from './user/user.module';
     }),
     AuthModule,
     UserModule,
+    LikeModule,
+    TestModule,
   ],
 })
 export class AppModule {}

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -5,7 +5,6 @@ import { MongooseModule } from '@nestjs/mongoose';
 import { AuthModule } from './auth/auth.module';
 import { UserModule } from './user/user.module';
 import { LikeModule } from './like/like.module';
-import { TestModule } from './test/test.module';
 
 @Module({
   imports: [
@@ -19,7 +18,6 @@ import { TestModule } from './test/test.module';
     AuthModule,
     UserModule,
     LikeModule,
-    TestModule,
   ],
 })
 export class AppModule {}

--- a/server/src/auth/auth.controller.spec.ts
+++ b/server/src/auth/auth.controller.spec.ts
@@ -3,7 +3,6 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
 import { UserService } from 'src/user/user.service';
-import { UserRepository } from 'src/user/user.repository';
 
 describe('AuthController', () => {
   let controller: AuthController;
@@ -12,7 +11,7 @@ describe('AuthController', () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [AuthController],
       providers: [
-        AuthService,
+        { provide: AuthService, useValue: {} },
         {
           provide: UserService,
           useValue: {},

--- a/server/src/like/dto/add-like.dto.ts
+++ b/server/src/like/dto/add-like.dto.ts
@@ -1,0 +1,6 @@
+import { IsString } from 'class-validator';
+
+export class AddLikeRequestDto {
+  @IsString()
+  likedId: string;
+}

--- a/server/src/like/dto/delete-like.dto.ts
+++ b/server/src/like/dto/delete-like.dto.ts
@@ -1,0 +1,6 @@
+import { IsString } from 'class-validator';
+
+export class DeleteLikeRequestDto {
+  @IsString()
+  likedId: string;
+}

--- a/server/src/like/entities/like.entity.ts
+++ b/server/src/like/entities/like.entity.ts
@@ -1,0 +1,1 @@
+export class Like {}

--- a/server/src/like/entities/like.entity.ts
+++ b/server/src/like/entities/like.entity.ts
@@ -1,1 +1,23 @@
-export class Like {}
+import { Document } from 'mongoose';
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { IsArray, IsString } from 'class-validator';
+
+@Schema({
+  versionKey: false,
+  timestamps: { createdAt: 'createdAt', updatedAt: 'updatedAt' },
+})
+export class Like extends Document {
+  @Prop({
+    required: true,
+  })
+  @IsString()
+  userId: string;
+
+  @Prop({
+    required: true,
+  })
+  @IsArray()
+  likedId: string[];
+}
+
+export const likeSchema = SchemaFactory.createForClass(Like);

--- a/server/src/like/entities/like.entity.ts
+++ b/server/src/like/entities/like.entity.ts
@@ -17,7 +17,7 @@ export class Like extends Document {
     required: true,
   })
   @IsArray()
-  likedId: string[];
+  likedIds: string[];
 }
 
 export const likeSchema = SchemaFactory.createForClass(Like);

--- a/server/src/like/like.controller.spec.ts
+++ b/server/src/like/like.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { LikeController } from './like.controller';
+import { LikeService } from './like.service';
+
+describe('LikeController', () => {
+  let controller: LikeController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [LikeController],
+      providers: [LikeService],
+    }).compile();
+
+    controller = module.get<LikeController>(LikeController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/server/src/like/like.controller.spec.ts
+++ b/server/src/like/like.controller.spec.ts
@@ -1,4 +1,9 @@
+import { getModelToken } from '@nestjs/mongoose';
 import { Test, TestingModule } from '@nestjs/testing';
+import { User } from 'src/user/entities/user.entity';
+import { UserModule } from 'src/user/user.module';
+import { UserService } from 'src/user/user.service';
+import { Like } from './entities/like.entity';
 import { LikeController } from './like.controller';
 import { LikeService } from './like.service';
 
@@ -8,7 +13,24 @@ describe('LikeController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [LikeController],
-      providers: [LikeService],
+      providers: [
+        {
+          provide: UserService,
+          useValue: {},
+        },
+        {
+          provide: LikeService,
+          useValue: {},
+        },
+        {
+          provide: getModelToken(Like.name),
+          useValue: Like,
+        },
+        {
+          provide: getModelToken(User.name),
+          useValue: User,
+        },
+      ],
     }).compile();
 
     controller = module.get<LikeController>(LikeController);

--- a/server/src/like/like.controller.ts
+++ b/server/src/like/like.controller.ts
@@ -3,6 +3,8 @@ import {
   Controller,
   Delete,
   Get,
+  HttpCode,
+  HttpStatus,
   Param,
   Post,
   Res,
@@ -20,6 +22,7 @@ export class LikeController {
   constructor(private readonly likeService: LikeService) {}
 
   @Post()
+  @HttpCode(HttpStatus.OK)
   addLike(
     @Body() likeDto: AddLikeRequestDto,
     @Session() session: Record<string, any>,
@@ -31,10 +34,11 @@ export class LikeController {
 
     this.likeService.addLike(likeDto, session.user);
 
-    return res.status(200).send(new SuccessResponse());
+    return new SuccessResponse();
   }
 
   @Delete()
+  @HttpCode(HttpStatus.OK)
   deleteLike(
     @Body() likeDto: AddLikeRequestDto,
     @Session() session: Record<string, any>,
@@ -46,14 +50,15 @@ export class LikeController {
 
     this.likeService.deleteLike(likeDto, session.user);
 
-    return res.status(200).send(new SuccessResponse());
+    return new SuccessResponse();
   }
 
   @Get('/:id')
+  @HttpCode(HttpStatus.OK)
   findLikes(@Param('id') id: string, @Res() res: Response) {
     // param 에 담긴 id 의 좋아요 리스트를 반환하는 service 로직 호출
 
     // 반한된 좋아요 리스트와 함께 응답
-    return res.status(200).send(new SuccessResponse());
+    return new SuccessResponse();
   }
 }

--- a/server/src/like/like.controller.ts
+++ b/server/src/like/like.controller.ts
@@ -5,10 +5,10 @@ import {
   Get,
   Param,
   Post,
-  Req,
   Res,
+  Session,
 } from '@nestjs/common';
-import { Request, Response } from 'express';
+import { Response } from 'express';
 
 import { LikeService } from './like.service';
 import { SuccessResponse } from 'src/common/response/success-response';
@@ -22,14 +22,14 @@ export class LikeController {
   @Post()
   addLike(
     @Body() likeDto: AddLikeRequestDto,
-    @Req() req: Request,
+    @Session() session: Record<string, any>,
     @Res() res: Response,
   ) {
-    if (!req.session.user) {
+    if (!session.user) {
       throw errors.NOT_LOGGED_IN;
     }
 
-    this.likeService.addLike(likeDto, req.session.user);
+    this.likeService.addLike(likeDto, session.user);
 
     return res.status(200).send(new SuccessResponse());
   }
@@ -37,14 +37,14 @@ export class LikeController {
   @Delete()
   deleteLike(
     @Body() likeDto: AddLikeRequestDto,
-    @Req() req: Request,
+    @Session() session: Record<string, any>,
     @Res() res: Response,
   ) {
-    if (!req.session.user) {
+    if (!session.user) {
       throw errors.NOT_LOGGED_IN;
     }
 
-    this.likeService.deleteLike(likeDto, req.session.user);
+    this.likeService.deleteLike(likeDto, session.user);
 
     return res.status(200).send(new SuccessResponse());
   }

--- a/server/src/like/like.controller.ts
+++ b/server/src/like/like.controller.ts
@@ -5,21 +5,34 @@ import {
   Get,
   Param,
   Post,
+  Req,
   Res,
 } from '@nestjs/common';
-import { Response } from 'express';
-import { SuccessResponse } from 'src/common/response/success-response';
-import { AddLikeRequestDto } from './dto/add-like.dto';
+import { Request, Response } from 'express';
 
 import { LikeService } from './like.service';
+import { SuccessResponse } from 'src/common/response/success-response';
+import { AddLikeRequestDto } from './dto/add-like.dto';
+import { errors } from 'src/common/response/error-response';
 
 @Controller('/api/like')
 export class LikeController {
   constructor(private readonly likeService: LikeService) {}
 
   @Post()
-  addLike(@Body() likeDto: AddLikeRequestDto, @Res() res: Response) {
+  addLike(
+    @Body() likeDto: AddLikeRequestDto,
+    @Req() req: Request,
+    @Res() res: Response,
+  ) {
+    console.log(req.session.user);
+
+    if (!req.session.user) {
+      throw errors.NOT_LOGGED_IN;
+    }
     // 좋아요를 추가하는 service 로직 호출
+
+    this.likeService.addLike(likeDto, req.session.user);
 
     return res.status(200).send(new SuccessResponse());
   }

--- a/server/src/like/like.controller.ts
+++ b/server/src/like/like.controller.ts
@@ -29,15 +29,22 @@ export class LikeController {
       throw errors.NOT_LOGGED_IN;
     }
 
-    // 좋아요를 추가하는 service 로직 호출
     this.likeService.addLike(likeDto, req.session.user);
 
     return res.status(200).send(new SuccessResponse());
   }
 
   @Delete()
-  deleteLike(@Body() likeDto: AddLikeRequestDto, @Res() res: Response) {
-    // 좋아요를 추가하는 service 로직 호출
+  deleteLike(
+    @Body() likeDto: AddLikeRequestDto,
+    @Req() req: Request,
+    @Res() res: Response,
+  ) {
+    if (!req.session.user) {
+      throw errors.NOT_LOGGED_IN;
+    }
+
+    this.likeService.deleteLike(likeDto, req.session.user);
 
     return res.status(200).send(new SuccessResponse());
   }

--- a/server/src/like/like.controller.ts
+++ b/server/src/like/like.controller.ts
@@ -25,13 +25,11 @@ export class LikeController {
     @Req() req: Request,
     @Res() res: Response,
   ) {
-    console.log(req.session.user);
-
     if (!req.session.user) {
       throw errors.NOT_LOGGED_IN;
     }
-    // 좋아요를 추가하는 service 로직 호출
 
+    // 좋아요를 추가하는 service 로직 호출
     this.likeService.addLike(likeDto, req.session.user);
 
     return res.status(200).send(new SuccessResponse());

--- a/server/src/like/like.controller.ts
+++ b/server/src/like/like.controller.ts
@@ -1,0 +1,8 @@
+import { Controller } from '@nestjs/common';
+
+import { LikeService } from './like.service';
+
+@Controller('/api/like')
+export class LikeController {
+  constructor(private readonly likeService: LikeService) {}
+}

--- a/server/src/like/like.controller.ts
+++ b/server/src/like/like.controller.ts
@@ -1,8 +1,41 @@
-import { Controller } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Post,
+  Res,
+} from '@nestjs/common';
+import { Response } from 'express';
+import { SuccessResponse } from 'src/common/response/success-response';
+import { AddLikeRequestDto } from './dto/add-like.dto';
 
 import { LikeService } from './like.service';
 
 @Controller('/api/like')
 export class LikeController {
   constructor(private readonly likeService: LikeService) {}
+
+  @Post()
+  addLike(@Body() likeDto: AddLikeRequestDto, @Res() res: Response) {
+    // 좋아요를 추가하는 service 로직 호출
+
+    return res.status(200).send(new SuccessResponse());
+  }
+
+  @Delete()
+  deleteLike(@Body() likeDto: AddLikeRequestDto, @Res() res: Response) {
+    // 좋아요를 추가하는 service 로직 호출
+
+    return res.status(200).send(new SuccessResponse());
+  }
+
+  @Get('/:id')
+  findLikes(@Param('id') id: string, @Res() res: Response) {
+    // param 에 담긴 id 의 좋아요 리스트를 반환하는 service 로직 호출
+
+    // 반한된 좋아요 리스트와 함께 응답
+    return res.status(200).send(new SuccessResponse());
+  }
 }

--- a/server/src/like/like.module.ts
+++ b/server/src/like/like.module.ts
@@ -1,10 +1,16 @@
 import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
 
 import { LikeService } from './like.service';
 import { LikeController } from './like.controller';
+import { LikeRepository } from './like.repository';
+import { Like, likeSchema } from './entities/like.entity';
 
 @Module({
+  imports: [
+    MongooseModule.forFeature([{ name: Like.name, schema: likeSchema }]),
+  ],
   controllers: [LikeController],
-  providers: [LikeService],
+  providers: [LikeService, LikeRepository],
 })
 export class LikeModule {}

--- a/server/src/like/like.module.ts
+++ b/server/src/like/like.module.ts
@@ -5,25 +5,14 @@ import { LikeService } from './like.service';
 import { LikeController } from './like.controller';
 import { LikeRepository } from './like.repository';
 import { Like, likeSchema } from './entities/like.entity';
-import { UserService } from 'src/user/user.service';
-import { UserRepository } from 'src/user/user.repository';
+import { UserModule } from 'src/user/user.module';
 
 @Module({
   imports: [
     MongooseModule.forFeature([{ name: Like.name, schema: likeSchema }]),
+    UserModule,
   ],
   controllers: [LikeController],
-  providers: [
-    LikeService,
-    LikeRepository,
-    {
-      provide: UserService,
-      useValue: {},
-    },
-    {
-      provide: UserRepository,
-      useValue: {},
-    },
-  ],
+  providers: [LikeService, LikeRepository],
 })
 export class LikeModule {}

--- a/server/src/like/like.module.ts
+++ b/server/src/like/like.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+
+import { LikeService } from './like.service';
+import { LikeController } from './like.controller';
+
+@Module({
+  controllers: [LikeController],
+  providers: [LikeService],
+})
+export class LikeModule {}

--- a/server/src/like/like.module.ts
+++ b/server/src/like/like.module.ts
@@ -5,12 +5,25 @@ import { LikeService } from './like.service';
 import { LikeController } from './like.controller';
 import { LikeRepository } from './like.repository';
 import { Like, likeSchema } from './entities/like.entity';
+import { UserService } from 'src/user/user.service';
+import { UserRepository } from 'src/user/user.repository';
 
 @Module({
   imports: [
     MongooseModule.forFeature([{ name: Like.name, schema: likeSchema }]),
   ],
   controllers: [LikeController],
-  providers: [LikeService, LikeRepository],
+  providers: [
+    LikeService,
+    LikeRepository,
+    {
+      provide: UserService,
+      useValue: {},
+    },
+    {
+      provide: UserRepository,
+      useValue: {},
+    },
+  ],
 })
 export class LikeModule {}

--- a/server/src/like/like.repository.ts
+++ b/server/src/like/like.repository.ts
@@ -11,4 +11,8 @@ export class LikeRepository {
   async findLikeByUserId(userId: string) {
     return await this.likeModel.findOne().where('userId').equals(userId);
   }
+
+  async updateLikeByLikedId(userId: string, likedId: string[]) {
+    return await this.likeModel.updateOne({ userId }, { $set: { likedId } });
+  }
 }

--- a/server/src/like/like.repository.ts
+++ b/server/src/like/like.repository.ts
@@ -1,0 +1,10 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+
+import { Like } from './entities/like.entity';
+
+@Injectable()
+export class LikeRepository {
+  constructor(@InjectModel(Like.name) private likeModel: Model<Like>) {}
+}

--- a/server/src/like/like.repository.ts
+++ b/server/src/like/like.repository.ts
@@ -7,4 +7,8 @@ import { Like } from './entities/like.entity';
 @Injectable()
 export class LikeRepository {
   constructor(@InjectModel(Like.name) private likeModel: Model<Like>) {}
+
+  async findLikeByUserId(userId: string) {
+    return await this.likeModel.findOne().where('userId').equals(userId);
+  }
 }

--- a/server/src/like/like.service.spec.ts
+++ b/server/src/like/like.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { LikeService } from './like.service';
+
+describe('LikeService', () => {
+  let service: LikeService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [LikeService],
+    }).compile();
+
+    service = module.get<LikeService>(LikeService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/server/src/like/like.service.spec.ts
+++ b/server/src/like/like.service.spec.ts
@@ -1,4 +1,6 @@
+import { getModelToken } from '@nestjs/mongoose';
 import { Test, TestingModule } from '@nestjs/testing';
+import { Like } from './entities/like.entity';
 import { LikeService } from './like.service';
 
 describe('LikeService', () => {
@@ -6,7 +8,16 @@ describe('LikeService', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [LikeService],
+      providers: [
+        {
+          provide: LikeService,
+          useValue: {},
+        },
+        {
+          provide: getModelToken(Like.name),
+          useValue: Like,
+        },
+      ],
     }).compile();
 
     service = module.get<LikeService>(LikeService);

--- a/server/src/like/like.service.spec.ts
+++ b/server/src/like/like.service.spec.ts
@@ -1,5 +1,6 @@
 import { getModelToken } from '@nestjs/mongoose';
 import { Test, TestingModule } from '@nestjs/testing';
+
 import { Like } from './entities/like.entity';
 import { LikeService } from './like.service';
 

--- a/server/src/like/like.service.ts
+++ b/server/src/like/like.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class LikeService {}

--- a/server/src/like/like.service.ts
+++ b/server/src/like/like.service.ts
@@ -1,4 +1,6 @@
 import { Injectable } from '@nestjs/common';
+
+import { errors } from 'src/common/response/error-response';
 import { UserInfo } from 'src/d';
 import { UserRepository } from 'src/user/user.repository';
 import { AddLikeRequestDto } from './dto/add-like.dto';
@@ -16,18 +18,28 @@ export class LikeService {
 
   // Like Document 에 좋아요 추가
   async addLike(likeDto: AddLikeRequestDto, userInfo: UserInfo) {
-    // 세션에 있는 정보로 User 의 ObjectId 조회
+    // 세션에 있는 사용자 정보로 User 의 ObjectId 조회
     const { authProvider, authId } = { ...userInfo };
     const user = await this.userRepository.findUserByAuthProviderAndAuthId(
       authProvider,
       authId,
     );
+    // 조회된 user 가 없다면, 에러 반환
+    if (!user) {
+      throw errors.NOT_MATCHED_USER;
+    }
 
-    console.log(user);
+    // 좋아요 리스트에 추가하고자 하는 likedId 가 올바른 지 확인
+    const likedUser = await this.userRepository.findUserById(likeDto.likedId);
+    if (!likedUser) {
+      throw errors.NOT_MATCHED_USER;
+    }
 
     // User 의 ObjectId 로 Like Document 조회
     const like = await this.likeRepository.findLikeByUserId(user._id);
+    const newLikedId = [...like.likedId, likeDto.likedId];
 
-    // Like Document 에 likedId 필드에 likeDto 의 likedId 값을 추가
+    // Like Document 에 likedId 필드에 likeDto 의 likedId 값을 추가(update);
+    return await this.likeRepository.updateLikeByLikedId(user._id, newLikedId);
   }
 }

--- a/server/src/like/like.service.ts
+++ b/server/src/like/like.service.ts
@@ -15,9 +15,6 @@ export class LikeService {
     private readonly userRepository: UserRepository,
   ) {}
 
-  // Like Document 생성
-  async create() {}
-
   // Like Document 에 좋아요 추가
   async addLike(likeDto: AddLikeRequestDto, userInfo: UserInfo) {
     const user = await this.checkUserExistByUserInfo(userInfo);

--- a/server/src/like/like.service.ts
+++ b/server/src/like/like.service.ts
@@ -1,4 +1,33 @@
 import { Injectable } from '@nestjs/common';
+import { UserInfo } from 'src/d';
+import { UserRepository } from 'src/user/user.repository';
+import { AddLikeRequestDto } from './dto/add-like.dto';
+import { LikeRepository } from './like.repository';
 
 @Injectable()
-export class LikeService {}
+export class LikeService {
+  constructor(
+    private readonly likeRepository: LikeRepository,
+    private readonly userRepository: UserRepository,
+  ) {}
+
+  // Like Document 생성
+  async create() {}
+
+  // Like Document 에 좋아요 추가
+  async addLike(likeDto: AddLikeRequestDto, userInfo: UserInfo) {
+    // 세션에 있는 정보로 User 의 ObjectId 조회
+    const { authProvider, authId } = { ...userInfo };
+    const user = await this.userRepository.findUserByAuthProviderAndAuthId(
+      authProvider,
+      authId,
+    );
+
+    console.log(user);
+
+    // User 의 ObjectId 로 Like Document 조회
+    const like = await this.likeRepository.findLikeByUserId(user._id);
+
+    // Like Document 에 likedId 필드에 likeDto 의 likedId 값을 추가
+  }
+}

--- a/server/src/like/like.service.ts
+++ b/server/src/like/like.service.ts
@@ -4,6 +4,7 @@ import { errors } from 'src/common/response/error-response';
 import { UserInfo } from 'src/d';
 import { UserRepository } from 'src/user/user.repository';
 import { AddLikeRequestDto } from './dto/add-like.dto';
+import { DeleteLikeRequestDto } from './dto/delete-like.dto';
 import { LikeRepository } from './like.repository';
 
 @Injectable()
@@ -38,6 +39,32 @@ export class LikeService {
     // User 의 ObjectId 로 Like Document 조회
     const like = await this.likeRepository.findLikeByUserId(user._id);
     const newLikedId = [...like.likedId, likeDto.likedId];
+
+    // Like Document 에 likedId 필드에 likeDto 의 likedId 값을 추가(update);
+    return await this.likeRepository.updateLikeByLikedId(user._id, newLikedId);
+  }
+
+  async deleteLike(likeDto: DeleteLikeRequestDto, userInfo: UserInfo) {
+    // 세션에 있는 사용자 정보로 User 의 ObjectId 조회
+    const { authProvider, authId } = { ...userInfo };
+    const user = await this.userRepository.findUserByAuthProviderAndAuthId(
+      authProvider,
+      authId,
+    );
+    // 조회된 user 가 없다면, 에러 반환
+    if (!user) {
+      throw errors.NOT_MATCHED_USER;
+    }
+
+    // 좋아요 리스트에 삭제하고자 하는 likedId 가 올바른 지 확인
+    const likedUser = await this.userRepository.findUserById(likeDto.likedId);
+    if (!likedUser) {
+      throw errors.NOT_MATCHED_USER;
+    }
+
+    // User 의 ObjectId 로 Like Document 조회
+    const like = await this.likeRepository.findLikeByUserId(user._id);
+    const newLikedId = like.likedId.filter((id) => id !== likeDto.likedId);
 
     // Like Document 에 likedId 필드에 likeDto 의 likedId 값을 추가(update);
     return await this.likeRepository.updateLikeByLikedId(user._id, newLikedId);

--- a/server/src/like/like.service.ts
+++ b/server/src/like/like.service.ts
@@ -17,30 +17,30 @@ export class LikeService {
 
   // Like Document 에 좋아요 추가
   async addLike(likeDto: AddLikeRequestDto, userInfo: UserInfo) {
-    const user = await this.checkUserExistByUserInfo(userInfo);
-    const likedUser = await this.checkUserExistById(likeDto.likedId);
+    const user = await this.getValidUserByUserInfo(userInfo);
+    const likedUser = await this.getValidUserById(likeDto.likedId);
 
     // User 의 ObjectId 로 Like Document 조회
     const like = await this.likeRepository.findLikeByUserId(user._id);
-    const newLikedId = [...like.likedId, likeDto.likedId];
+    const newLikedId = [...like.likedIds, likedUser._id];
 
     // Like Document 에 likedId 필드에 likeDto 의 likedId 값을 추가(update);
     return await this.likeRepository.updateLikeByLikedId(user._id, newLikedId);
   }
 
   async deleteLike(likeDto: DeleteLikeRequestDto, userInfo: UserInfo) {
-    const user = await this.checkUserExistByUserInfo(userInfo);
-    const likedUser = await this.checkUserExistById(likeDto.likedId);
+    const user = await this.getValidUserByUserInfo(userInfo);
+    const likedUser = await this.getValidUserById(likeDto.likedId);
 
     // User 의 ObjectId 로 Like Document 조회
     const like = await this.likeRepository.findLikeByUserId(user._id);
-    const newLikedId = like.likedId.filter((id) => id !== likeDto.likedId);
+    const newLikedId = like.likedIds.filter((id) => id !== likedUser._id);
 
     // Like Document 에 likedId 필드에 likeDto 의 likedId 값을 추가(update);
     return await this.likeRepository.updateLikeByLikedId(user._id, newLikedId);
   }
 
-  async checkUserExistByUserInfo(userInfo: UserInfo): Promise<User> {
+  async getValidUserByUserInfo(userInfo: UserInfo): Promise<User> {
     // 세션에 있는 사용자 정보로 User 의 ObjectId 조회
     const { authProvider, authId } = { ...userInfo };
     const user = await this.userRepository.findUserByAuthProviderAndAuthId(
@@ -56,7 +56,7 @@ export class LikeService {
     return user;
   }
 
-  async checkUserExistById(id: string): Promise<User> {
+  async getValidUserById(id: string): Promise<User> {
     const user = await this.userRepository.findUserById(id);
     if (!user) {
       throw errors.NOT_MATCHED_USER;

--- a/server/src/like/like.service.ts
+++ b/server/src/like/like.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 
 import { errors } from 'src/common/response/error-response';
 import { UserInfo } from 'src/d';
+import { User } from 'src/user/entities/user.entity';
 import { UserRepository } from 'src/user/user.repository';
 import { AddLikeRequestDto } from './dto/add-like.dto';
 import { DeleteLikeRequestDto } from './dto/delete-like.dto';
@@ -19,22 +20,8 @@ export class LikeService {
 
   // Like Document 에 좋아요 추가
   async addLike(likeDto: AddLikeRequestDto, userInfo: UserInfo) {
-    // 세션에 있는 사용자 정보로 User 의 ObjectId 조회
-    const { authProvider, authId } = { ...userInfo };
-    const user = await this.userRepository.findUserByAuthProviderAndAuthId(
-      authProvider,
-      authId,
-    );
-    // 조회된 user 가 없다면, 에러 반환
-    if (!user) {
-      throw errors.NOT_MATCHED_USER;
-    }
-
-    // 좋아요 리스트에 추가하고자 하는 likedId 가 올바른 지 확인
-    const likedUser = await this.userRepository.findUserById(likeDto.likedId);
-    if (!likedUser) {
-      throw errors.NOT_MATCHED_USER;
-    }
+    const user = await this.checkUserExistByUserInfo(userInfo);
+    const likedUser = await this.checkUserExistById(likeDto.likedId);
 
     // User 의 ObjectId 로 Like Document 조회
     const like = await this.likeRepository.findLikeByUserId(user._id);
@@ -45,22 +32,8 @@ export class LikeService {
   }
 
   async deleteLike(likeDto: DeleteLikeRequestDto, userInfo: UserInfo) {
-    // 세션에 있는 사용자 정보로 User 의 ObjectId 조회
-    const { authProvider, authId } = { ...userInfo };
-    const user = await this.userRepository.findUserByAuthProviderAndAuthId(
-      authProvider,
-      authId,
-    );
-    // 조회된 user 가 없다면, 에러 반환
-    if (!user) {
-      throw errors.NOT_MATCHED_USER;
-    }
-
-    // 좋아요 리스트에 삭제하고자 하는 likedId 가 올바른 지 확인
-    const likedUser = await this.userRepository.findUserById(likeDto.likedId);
-    if (!likedUser) {
-      throw errors.NOT_MATCHED_USER;
-    }
+    const user = await this.checkUserExistByUserInfo(userInfo);
+    const likedUser = await this.checkUserExistById(likeDto.likedId);
 
     // User 의 ObjectId 로 Like Document 조회
     const like = await this.likeRepository.findLikeByUserId(user._id);
@@ -68,5 +41,30 @@ export class LikeService {
 
     // Like Document 에 likedId 필드에 likeDto 의 likedId 값을 추가(update);
     return await this.likeRepository.updateLikeByLikedId(user._id, newLikedId);
+  }
+
+  async checkUserExistByUserInfo(userInfo: UserInfo): Promise<User> {
+    // 세션에 있는 사용자 정보로 User 의 ObjectId 조회
+    const { authProvider, authId } = { ...userInfo };
+    const user = await this.userRepository.findUserByAuthProviderAndAuthId(
+      authProvider,
+      authId,
+    );
+
+    // 조회된 user 가 없다면, 에러 반환
+    if (!user) {
+      throw errors.NOT_MATCHED_USER;
+    }
+
+    return user;
+  }
+
+  async checkUserExistById(id: string): Promise<User> {
+    const user = await this.userRepository.findUserById(id);
+    if (!user) {
+      throw errors.NOT_MATCHED_USER;
+    }
+
+    return user;
   }
 }

--- a/server/src/user/dto/create-user.dto.ts
+++ b/server/src/user/dto/create-user.dto.ts
@@ -1,4 +1,4 @@
-import { IsArray, IsEmail, IsString } from 'class-validator';
+import { IsArray, IsString } from 'class-validator';
 
 export class CreateUserRequestDto {
   @IsString()

--- a/server/src/user/user.module.ts
+++ b/server/src/user/user.module.ts
@@ -12,6 +12,6 @@ import { UserRepository } from './user.repository';
   ],
   controllers: [UserController],
   providers: [UserService, UserRepository],
-  exports: [UserService],
+  exports: [UserService, UserRepository],
 })
 export class UserModule {}

--- a/server/src/user/user.repository.ts
+++ b/server/src/user/user.repository.ts
@@ -27,6 +27,10 @@ export class UserRepository {
     return await this.userModel.findOne().where('username').equals(username);
   }
 
+  async findUserById(id: string) {
+    return await this.userModel.findOne().where('_id').equals(id);
+  }
+
   async delete(user: User) {
     return await this.userModel.deleteOne({ id: user.id });
   }

--- a/server/src/user/user.service.ts
+++ b/server/src/user/user.service.ts
@@ -16,6 +16,9 @@ export class UserService {
     userDto: CreateUserRequestDto,
     userInfo: UserInfo,
   ): Promise<User> {
+    // fix 할 때 고칠 내용, ci 를 통과하기 위해 잠시 사용
+    userInfo;
+
     // 유효성 검사
     this.validateUsername(userDto.username);
 


### PR DESCRIPTION
## 📕 제목

- https://github.com/boostcampwm-2022/web25-SCOPA/issues/66

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] `like` resource 생성
   - `nest g resource like` 사용
- [x] `AddLikeRequestDto` 구현
- [x] `like.controller.ts` 틀 잡기
- [x] Like Entity 구현
- [x] LikeRepository 구현
- [x] `/api/like` 좋아요 추가(post) 에 필요한 service, repository 로직 구현
   1) 세션에 있는 사용자 정보로 User document 조회
   2) 조회되는 User 가 없으면, `NOT_MATCHED_USER` 에러 반환
   3) 좋아요 리스트에 추가하고자 하는 `likedId` 가 올바른 지 확인하기 위해, `likedId` 와 일치하는 User document 조회
   4) 마찬가지로 조회되는 User 가 없으면, `NOT_MATCHED_USER` 에러 반환
   5) 1번에서 조회한 User 의 ObjectId 값으로 Like document 조회
   6) Like document 의 좋아요 배열에 새로운 좋아요를 추가함으로써, `newLikedId` 생성
   7) `newLikedId` 로 Like document 를 업데이트
- [x] `DeleteLikeRequestDto` 구현
- [x] `/api/like` 좋아요 삭제(delete) 에 필요한 service, repository 로직 구현
   1) 세션에 있는 사용자 정보로 User document 조회
   2) 조회되는 User 가 없으면, `NOT_MATCHED_USER` 에러 반환
   3) 좋아요 리스트에 제거하고자 하는 `likedId` 가 올바른 지 확인하기 위해, `likedId` 와 일치하는 User document 조회
   4) 마찬가지로 조회되는 User 가 없으면, `NOT_MATCHED_USER` 에러 반환
   5) 1번에서 조회한 User 의 ObjectId 값으로 Like document 조회
   6) Like document 의 좋아요 배열에 `filter` 고차함수로 제거하고자 하는 `likedId` 를 제거
   7) `newLikedId` 로 Like document 를 업데이트
- [x] 공통되는 로직을 함수로 뺍니다.
   1) 세션에 있는 사용자 정보로 User 조회하고 없다면 에러 반환하는 로직
   2) id 로 User 조회하고 에러 반환하는 로직

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- `*.spec.ts` 로 끝나는 파일은 안 보셔도 됩니다. 테스트를 위한 코드인데, 아직 테스트 코드를 작성 못하고 있습니다. 빠른 시일내에 테스트 코드를 작성해보도록 하겠습니다.

close #66 