### PR TITLE
[Feat] FE. 회원가입화면 서버측 ID유효성 검사 결과 안내

### DIFF
--- a/client/src/pages/RegisterPage/IdInput.tsx
+++ b/client/src/pages/RegisterPage/IdInput.tsx
@@ -103,7 +103,7 @@ export const IdInput = ({ setId }: { setId: Dispatch<SetStateAction<string>> }) 
         </button>
       </div>
       {idWarning.length > 0 && <span css={idValidationWarningStyle}>{idWarning}</span>}
-      {serverCheck.length > 0 && <span css={serverCheckResultStyle}> {serverCheck}</span>}
+      {idWarning.length === 0 && serverCheck.length > 0 && <span css={serverCheckResultStyle}> {serverCheck}</span>}
     </div>
   );
 };

--- a/client/src/pages/RegisterPage/IdInput.tsx
+++ b/client/src/pages/RegisterPage/IdInput.tsx
@@ -3,14 +3,13 @@
 import React, { Dispatch, SetStateAction, useCallback, useEffect, useState } from 'react';
 import { css } from '@emotion/react';
 
-import { API } from 'utils/constants';
+import { API, RESULT } from 'utils/constants';
 
 import {
-  idValidationWarningStyle,
+  idValidationStyle,
   registerPageIdButtonStyle,
   registerPageInputStyle,
   registerPageInputWrapperStyle,
-  serverCheckResultStyle,
 } from './styles';
 
 export const IdInput = ({ setId }: { setId: Dispatch<SetStateAction<string>> }) => {
@@ -89,6 +88,12 @@ export const IdInput = ({ setId }: { setId: Dispatch<SetStateAction<string>> }) 
     setIdWarning('');
   }, [idDraft]);
 
+  const isAllValid = useCallback(() => {
+    if (idWarning.length > 0) return RESULT.FAIL;
+    if (idDuplicationCheckResult.length > 0) return RESULT.SUCCESS;
+    return RESULT.NULL;
+  }, [idWarning, idDuplicationCheckResult]);
+
   return (
     <div>
       <div css={registerPageInputWrapperStyle}>
@@ -102,9 +107,10 @@ export const IdInput = ({ setId }: { setId: Dispatch<SetStateAction<string>> }) 
           <span>중복확인</span>
         </button>
       </div>
-      {idWarning.length > 0 && <span css={idValidationWarningStyle}>{idWarning}</span>}
-      {idWarning.length === 0 && idDuplicationCheckResult.length > 0 && (
-        <span css={serverCheckResultStyle}> {idDuplicationCheckResult}</span>
+      {isAllValid() !== RESULT.NULL && (
+        <span css={idValidationStyle(isAllValid())}>
+          {isAllValid() === RESULT.FAIL ? idWarning : idDuplicationCheckResult}
+        </span>
       )}
     </div>
   );

--- a/client/src/pages/RegisterPage/IdInput.tsx
+++ b/client/src/pages/RegisterPage/IdInput.tsx
@@ -10,11 +10,13 @@ import {
   registerPageIdButtonStyle,
   registerPageInputStyle,
   registerPageInputWrapperStyle,
+  serverCheckResultStyle,
 } from './styles';
 
 export const IdInput = ({ setId }: { setId: Dispatch<SetStateAction<string>> }) => {
   const [idDraft, setIdDraft] = useState<string>('');
   const [idWarning, setIdWarning] = useState<string>('');
+  const [serverCheck, setServerCheck] = useState<string>('');
 
   // 아이디값 입력에 따른 상태관리
   const handleOnChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
@@ -29,15 +31,19 @@ export const IdInput = ({ setId }: { setId: Dispatch<SetStateAction<string>> }) 
       .then((res) => {
         if (res.code === 10000) {
           setId(idDraft);
+          setServerCheck('유효한 아이디 입니다.');
           return;
         }
         if (res.code === 20001) {
-          alert('유효하지 않은 Id 형식입니다.');
+          setIdWarning('유효하지 않은 Id 형식입니다.');
           return;
         }
         if (res.code === 20002) {
-          alert('중복되는 Id 입니다.');
+          setIdWarning('중복되는 Id 입니다.');
         }
+      })
+      .catch(() => {
+        setIdWarning('중복검사에 실패했습니다.');
       });
   }, [idDraft]);
 
@@ -71,6 +77,7 @@ export const IdInput = ({ setId }: { setId: Dispatch<SetStateAction<string>> }) 
 
   // 사용자가 id값을 입력할때마다 검사
   useEffect(() => {
+    setServerCheck('');
     if (!isValidIdStr(idDraft)) {
       setIdWarning('알파벳과 숫자로만 이루어져야 합니다.');
       return;
@@ -96,6 +103,7 @@ export const IdInput = ({ setId }: { setId: Dispatch<SetStateAction<string>> }) 
         </button>
       </div>
       {idWarning.length > 0 && <span css={idValidationWarningStyle}>{idWarning}</span>}
+      {serverCheck.length > 0 && <span css={serverCheckResultStyle}> {serverCheck}</span>}
     </div>
   );
 };

--- a/client/src/pages/RegisterPage/IdInput.tsx
+++ b/client/src/pages/RegisterPage/IdInput.tsx
@@ -68,7 +68,7 @@ export const IdInput = ({ setId }: { setId: Dispatch<SetStateAction<string>> }) 
   // id값이 유효하면 서버로 보내주기
   const handleClick = useCallback(() => {
     if (!isValidId()) {
-      setIdWarning('4글자 이상, 10글자 이하의 알파벳과 숫자로 작성바랍니다.');
+      setIdWarning('4글자 이상, 15글자 이하의 알파벳과 숫자로 작성바랍니다.');
       return;
     }
     sendIdToServer();
@@ -82,7 +82,7 @@ export const IdInput = ({ setId }: { setId: Dispatch<SetStateAction<string>> }) 
       return;
     }
     if (!isValidIdLength(idDraft)) {
-      setIdWarning('4글자 이상 10글자 이하만 가능합니다.');
+      setIdWarning('4글자 이상 15글자 이하만 가능합니다.');
       return;
     }
     setIdWarning('');

--- a/client/src/pages/RegisterPage/IdInput.tsx
+++ b/client/src/pages/RegisterPage/IdInput.tsx
@@ -16,7 +16,7 @@ import {
 export const IdInput = ({ setId }: { setId: Dispatch<SetStateAction<string>> }) => {
   const [idDraft, setIdDraft] = useState<string>('');
   const [idWarning, setIdWarning] = useState<string>('');
-  const [serverCheck, setServerCheck] = useState<string>('');
+  const [idUniqueCheckResult, setIdUniqueCheckResult] = useState<string>('');
 
   // 아이디값 입력에 따른 상태관리
   const handleOnChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
@@ -31,7 +31,7 @@ export const IdInput = ({ setId }: { setId: Dispatch<SetStateAction<string>> }) 
       .then((res) => {
         if (res.code === 10000) {
           setId(idDraft);
-          setServerCheck('유효한 아이디 입니다.');
+          setIdUniqueCheckResult('유효한 아이디 입니다.');
           return;
         }
         if (res.code === 20001) {
@@ -77,7 +77,7 @@ export const IdInput = ({ setId }: { setId: Dispatch<SetStateAction<string>> }) 
 
   // 사용자가 id값을 입력할때마다 검사
   useEffect(() => {
-    setServerCheck('');
+    setIdUniqueCheckResult('');
     if (!isValidIdStr(idDraft)) {
       setIdWarning('알파벳과 숫자로만 이루어져야 합니다.');
       return;
@@ -103,7 +103,9 @@ export const IdInput = ({ setId }: { setId: Dispatch<SetStateAction<string>> }) 
         </button>
       </div>
       {idWarning.length > 0 && <span css={idValidationWarningStyle}>{idWarning}</span>}
-      {idWarning.length === 0 && serverCheck.length > 0 && <span css={serverCheckResultStyle}> {serverCheck}</span>}
+      {idWarning.length === 0 && idUniqueCheckResult.length > 0 && (
+        <span css={serverCheckResultStyle}> {idUniqueCheckResult}</span>
+      )}
     </div>
   );
 };

--- a/client/src/pages/RegisterPage/IdInput.tsx
+++ b/client/src/pages/RegisterPage/IdInput.tsx
@@ -16,7 +16,7 @@ import {
 export const IdInput = ({ setId }: { setId: Dispatch<SetStateAction<string>> }) => {
   const [idDraft, setIdDraft] = useState<string>('');
   const [idWarning, setIdWarning] = useState<string>('');
-  const [idUniqueCheckResult, setIdUniqueCheckResult] = useState<string>('');
+  const [idDuplicationCheckResult, setIdDuplicationCheckResult] = useState<string>('');
 
   // 아이디값 입력에 따른 상태관리
   const handleOnChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
@@ -31,7 +31,7 @@ export const IdInput = ({ setId }: { setId: Dispatch<SetStateAction<string>> }) 
       .then((res) => {
         if (res.code === 10000) {
           setId(idDraft);
-          setIdUniqueCheckResult('유효한 아이디 입니다.');
+          setIdDuplicationCheckResult('유효한 아이디 입니다.');
           return;
         }
         if (res.code === 20001) {
@@ -77,7 +77,7 @@ export const IdInput = ({ setId }: { setId: Dispatch<SetStateAction<string>> }) 
 
   // 사용자가 id값을 입력할때마다 검사
   useEffect(() => {
-    setIdUniqueCheckResult('');
+    setIdDuplicationCheckResult('');
     if (!isValidIdStr(idDraft)) {
       setIdWarning('알파벳과 숫자로만 이루어져야 합니다.');
       return;
@@ -103,8 +103,8 @@ export const IdInput = ({ setId }: { setId: Dispatch<SetStateAction<string>> }) 
         </button>
       </div>
       {idWarning.length > 0 && <span css={idValidationWarningStyle}>{idWarning}</span>}
-      {idWarning.length === 0 && idUniqueCheckResult.length > 0 && (
-        <span css={serverCheckResultStyle}> {idUniqueCheckResult}</span>
+      {idWarning.length === 0 && idDuplicationCheckResult.length > 0 && (
+        <span css={serverCheckResultStyle}> {idDuplicationCheckResult}</span>
       )}
     </div>
   );

--- a/client/src/pages/RegisterPage/styles.ts
+++ b/client/src/pages/RegisterPage/styles.ts
@@ -2,6 +2,7 @@ import { css } from '@emotion/react';
 
 import { COLORS } from 'styles/colors';
 import { COMMON_SIZE, FONT_SIZE } from 'styles/sizes';
+import { RESULT } from 'utils/constants';
 
 export const registerPageInnerStyle = css({
   display: 'grid',
@@ -68,12 +69,8 @@ export const registerPageButtonStyle = (isAllSet: boolean) =>
     opacity: isAllSet ? 1 : 0.5,
   });
 
-export const idValidationWarningStyle = css({
-  color: 'red',
-  fontSize: FONT_SIZE.SMALL,
-});
-
-export const serverCheckResultStyle = css({
-  color: 'green',
-  fontSize: FONT_SIZE.SMALL,
-});
+export const idValidationStyle = (isAllValid: string) =>
+  css({
+    color: isAllValid === RESULT.SUCCESS ? 'green' : 'red',
+    fontSize: FONT_SIZE.SMALL,
+  });

--- a/client/src/pages/RegisterPage/styles.ts
+++ b/client/src/pages/RegisterPage/styles.ts
@@ -72,3 +72,8 @@ export const idValidationWarningStyle = css({
   color: 'red',
   fontSize: FONT_SIZE.SMALL,
 });
+
+export const serverCheckResultStyle = css({
+  color: 'green',
+  fontSize: FONT_SIZE.SMALL,
+});

--- a/client/src/utils/constants.ts
+++ b/client/src/utils/constants.ts
@@ -32,3 +32,5 @@ export const API: Readonly<{ [key: string]: string }> = {
   PROFILE: '/profile',
   LIKE: '/like',
 };
+
+export const RESULT = { SUCCESS: 'SUCCESS', FAIL: 'FAIL', NULL: 'NULL' };


### PR DESCRIPTION
## 📕 제목

[Feat] FE. 회원가입화면 서버측 ID유효성 검사 결과 안내
관련이슈 #68 

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역
![image](https://user-images.githubusercontent.com/58356151/203453128-2fd02419-2e2f-478c-8954-14db42cab8e3.png)

- [x] 서버측 ID 유효성 검사 결과를 ID 입력창 하단에 표시

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 서버측 ID 유효성 검사 결과를 원래 alert를 통해 유저에게 안내하였었는데, UI/UX 상 입력창 하단에 표기해주는 것이 좋을 것 같아, 변경하였습니다.
