### PR TITLE
[Feat] BE. profile mock api 구현

### DIFF
--- a/server/src/common/http-execption-filter.ts
+++ b/server/src/common/http-execption-filter.ts
@@ -51,18 +51,18 @@ export class HttpExceptionFilter implements ExceptionFilter {
     if (this.isErrorInfoType(exception)) {
       return new CustomException(...(exception as ErrorInfo));
     }
+    console.log((exception as Error)?.stack);
     // 이외 build in exception 혹은 custom exception
     if (exception instanceof HttpException) {
       return new CustomException(
         exception instanceof CustomException
           ? exception.getCode()
           : UNDEFIND_CODE,
-        exception.message,
+        (exception.getResponse() as any)?.message,
         exception.getStatus(),
       );
     }
     // 처리하지 못한 모든 오류는 internal server error
-    console.log(exception);
     return new CustomException(...errors.INTERNER_ERROR);
   }
 }

--- a/server/src/common/http-execption-filter.ts
+++ b/server/src/common/http-execption-filter.ts
@@ -58,7 +58,7 @@ export class HttpExceptionFilter implements ExceptionFilter {
         exception instanceof CustomException
           ? exception.getCode()
           : UNDEFIND_CODE,
-        (exception.getResponse() as any)?.message,
+        (exception.getResponse() as Record<string, any>)?.message,
         exception.getStatus(),
       );
     }

--- a/server/src/common/response/error-response.ts
+++ b/server/src/common/response/error-response.ts
@@ -4,7 +4,11 @@ import { ErrorInfo, ErrorResponse } from '../../d';
 
 export class CustomException extends HttpException {
   private readonly code: number;
-  constructor(code: number, message: string, statusCode: number) {
+  constructor(
+    code: number,
+    message: string | Record<string, any>,
+    statusCode: number,
+  ) {
     super(message, statusCode);
     this.code = code;
   }
@@ -16,7 +20,7 @@ export class CustomException extends HttpException {
   getErrorResponse(): ErrorResponse {
     return {
       code: this.code,
-      message: this.message,
+      message: this.getResponse(),
     };
   }
 }

--- a/server/src/d.ts
+++ b/server/src/d.ts
@@ -10,5 +10,5 @@ export type ErrorInfo = [number, string, HttpStatus];
 
 export interface ErrorResponse {
   code: number;
-  message: string | object;
+  message: string | Record<string, any>;
 }

--- a/server/src/d.ts
+++ b/server/src/d.ts
@@ -10,5 +10,5 @@ export type ErrorInfo = [number, string, HttpStatus];
 
 export interface ErrorResponse {
   code: number;
-  message: string;
+  message: string | object;
 }

--- a/server/src/user/dto/create-user.dto.ts
+++ b/server/src/user/dto/create-user.dto.ts
@@ -1,17 +1,26 @@
-import { IsArray, IsString } from 'class-validator';
+import {
+  ArrayMaxSize,
+  IsArray,
+  IsString,
+  MaxLength,
+  MinLength,
+} from 'class-validator';
 
 import { AuthInfo } from 'src/d';
 import { User } from 'src/user/entities/user.entity';
 
 export class CreateUserRequestDto {
   @IsString()
+  @MinLength(4)
+  @MaxLength(15)
   username: string;
 
   @IsString()
   interest: string;
 
   @IsArray()
-  techStack: string[];
+  @ArrayMaxSize(3)
+  skills: string[];
 
   toEntity(authInfo?: AuthInfo): User {
     const userDto = { ...this, ...authInfo };

--- a/server/src/user/dto/find-user.dto.ts
+++ b/server/src/user/dto/find-user.dto.ts
@@ -1,0 +1,73 @@
+import {
+  ArrayMaxSize,
+  IsArray,
+  IsBoolean,
+  IsEmail,
+  IsNumber,
+  IsOptional,
+  IsString,
+  MaxLength,
+  MinLength,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class FindUserRequestDto {
+  @IsString()
+  @IsOptional()
+  interest?: string;
+
+  @IsString()
+  @IsOptional()
+  skill1?: string;
+
+  @IsString()
+  @IsOptional()
+  skill2?: string;
+
+  @IsString()
+  @IsOptional()
+  skill3?: string;
+
+  @Type(() => Boolean)
+  @IsOptional()
+  liked?: boolean;
+
+  @Type(() => Number)
+  @IsNumber()
+  @IsOptional()
+  pages = 1;
+}
+
+export class FindUserResponseDto {
+  @IsString()
+  @MinLength(4)
+  @MaxLength(15)
+  username: string;
+
+  @IsString()
+  code: string;
+
+  @IsString()
+  interest: string;
+
+  @IsArray()
+  @ArrayMaxSize(3)
+  skills: string[];
+
+  @IsString()
+  worktype: string;
+
+  @IsString()
+  worktime: string;
+
+  @IsEmail()
+  email: string;
+
+  @IsArray()
+  @IsString({ each: true })
+  @ArrayMaxSize(2)
+  requirements: string[];
+
+  @IsBoolean()
+  liked: boolean;
+}

--- a/server/src/user/dto/page-user.dto.ts
+++ b/server/src/user/dto/page-user.dto.ts
@@ -1,0 +1,48 @@
+import {
+  ArrayMaxSize,
+  IsArray,
+  IsBoolean,
+  IsNumber,
+  IsString,
+  Min,
+} from 'class-validator';
+
+export class PageUserResponseDto {
+  @IsNumber()
+  @Min(0)
+  totalPage: number; // 전체 페이지 수
+
+  @IsNumber()
+  @Min(0)
+  currentPage: number; // 현재 페이지 번호
+
+  @IsNumber()
+  @Min(0)
+  totalNumOfData: number; // 총 데이터 개수
+
+  @IsArray()
+  list: SimplaUserResponseDto[];
+}
+
+class SimplaUserResponseDto {
+  @IsString()
+  id: string;
+
+  @IsString()
+  language: string;
+
+  @IsString()
+  code: string;
+
+  @IsArray()
+  @IsString({ each: true })
+  skills: string[];
+
+  @IsArray()
+  @IsString({ each: true })
+  @ArrayMaxSize(2)
+  requirements: string[];
+
+  @IsBoolean()
+  liked: boolean;
+}

--- a/server/src/user/dto/update-user.dto.ts
+++ b/server/src/user/dto/update-user.dto.ts
@@ -1,0 +1,39 @@
+import {
+  ArrayMaxSize,
+  IsArray,
+  IsEmail,
+  IsString,
+  MaxLength,
+  MinLength,
+} from 'class-validator';
+
+export class UpdateUserRequestDto {
+  @IsString()
+  @MinLength(4)
+  @MaxLength(15)
+  username: string;
+
+  @IsString()
+  code: string;
+
+  @IsString()
+  interest: string;
+
+  @IsArray()
+  @ArrayMaxSize(3)
+  skills: string[];
+
+  @IsString()
+  worktype: string;
+
+  @IsString()
+  worktime: string;
+
+  @IsEmail()
+  email: string;
+
+  @IsArray()
+  @IsString({ each: true })
+  @ArrayMaxSize(2)
+  requirements: string[];
+}

--- a/server/src/user/user.controller.ts
+++ b/server/src/user/user.controller.ts
@@ -2,9 +2,11 @@ import {
   Controller,
   Get,
   Post,
+  Put,
+  Delete,
+  Param,
   Body,
   Query,
-  Delete,
   Session,
 } from '@nestjs/common';
 
@@ -12,12 +14,13 @@ import { UserService } from './user.service';
 import { CreateUserRequestDto } from './dto/create-user.dto';
 import { errors } from 'src/common/response/error-response';
 import { SuccessResponse } from 'src/common/response/success-response';
+import { UpdateUserRequestDto } from './dto/update-user.dto';
+import { FindUserRequestDto, FindUserResponseDto } from './dto/find-user.dto';
 
 @Controller('/api/users')
 export class UserController {
   constructor(private readonly userService: UserService) {}
 
-  // 회원가입
   @Post('/register')
   async create(
     @Body() userDto: CreateUserRequestDto,
@@ -36,12 +39,6 @@ export class UserController {
     return new SuccessResponse();
   }
 
-  // 전체 유저 조회
-  @Get()
-  findAll() {
-    return this.userService.findAll();
-  }
-
   // 아이디 유효성 & 중복 조회
   @Get('/validate')
   async validateRegisterId(@Query('id') id: string) {
@@ -55,7 +52,6 @@ export class UserController {
     return new SuccessResponse();
   }
 
-  // 회원 탈퇴
   @Delete('/withdraw')
   withdraw(@Session() session: Record<string, any>) {
     if (!session.userId) {
@@ -65,5 +61,65 @@ export class UserController {
     this.userService.remove(session.userId);
 
     return new SuccessResponse();
+  }
+
+  @Put('/edit')
+  async edit(
+    @Body() updateUserRequestDto: UpdateUserRequestDto,
+    @Session() session: Record<string, any>,
+  ) {
+    if (!session.userId) {
+      throw errors.NOT_LOGGED_IN;
+    }
+
+    return new SuccessResponse(updateUserRequestDto);
+  }
+
+  @Get('/:id')
+  async findProfile(
+    @Param('id') userId: string,
+  ): Promise<SuccessResponse<FindUserResponseDto>> {
+    // 임시 데이터
+    console.log(userId);
+    const mockUser = {
+      username: 'limited-hyeon',
+      code: `console.log('hello world');\nreturn(0);`,
+      interest: 'frontemd',
+      skills: ['react', 'typescript'],
+      worktype: '페어 프로그래밍, 잠실역 근처',
+      worktime: '새벽은 타협 가능하고 오후 1시부터 항상 비어있어요',
+      email: 'earlybird@boostcamp.org',
+      requirements: ['잠실사는사람만', '소통좋아해요'],
+      liked: true,
+    };
+    return new SuccessResponse(mockUser);
+  }
+
+  @Get()
+  async findAllProfiles(@Query() findUserRequestDto: FindUserRequestDto) {
+    // 임시 데이터
+    const list = [];
+    const skills = [];
+    findUserRequestDto.skill1 && skills.push(findUserRequestDto.skill1);
+    findUserRequestDto.skill2 && skills.push(findUserRequestDto.skill2);
+    findUserRequestDto.skill3 && skills.push(findUserRequestDto.skill3);
+    for (let i = 0; i < 6; i++) {
+      list.push({
+        id: '12345', // 상세 페이지 조회 및 좋아요 용도
+        language: 'JavaScript',
+        code: `console.log('hello world');\nreturn(0);`, // 프론트엔드에서 잘라서 사용
+        skills,
+        requirements: ['잠실사는사람만', '소통좋아해요'],
+        liked: true,
+      });
+    }
+
+    const response = {
+      totalPage: 10, // 전체 페이지 수
+      currentPage: findUserRequestDto.pages, // 현재 페이지 번호
+      totalNumOfData: 63, // 총 데이터 개수
+      list,
+    };
+    return new SuccessResponse(response);
   }
 }


### PR DESCRIPTION
## 📕 제목

관련이슈 #85

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] `/api/users/edit` 구현
- [x] `/api/users/:id` 구현
- [x] `/api/users?interest=frontend&skill1=A&skill2=B&skill3=C&liked=true&pages=1` 구현
- [x] custom exception이 아닌 exception의 error message도 반환하도록 수정

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- controller에서 임시 데이터를 만들어서 보내주고 있습니다.
- mock api이지만 input 유효성 검사는 수행하고 있습니다.
