### PR TITLE
[Test] Like 도메인 통합 테스트

### DIFF
--- a/server/src/like/like.controller.ts
+++ b/server/src/like/like.controller.ts
@@ -2,10 +2,8 @@ import {
   Body,
   Controller,
   Delete,
-  Get,
   HttpCode,
   HttpStatus,
-  Param,
   Post,
   Session,
 } from '@nestjs/common';
@@ -45,15 +43,6 @@ export class LikeController {
 
     await this.likeService.deleteLike(likeDto, session.userId);
 
-    return new SuccessResponse();
-  }
-
-  @Get('/:id')
-  @HttpCode(HttpStatus.OK)
-  async findLikes(@Param('id') id: string) {
-    // param 에 담긴 id 의 좋아요 리스트를 반환하는 service 로직 호출
-
-    // 반한된 좋아요 리스트와 함께 응답
     return new SuccessResponse();
   }
 }

--- a/server/src/like/like.integration.spec.ts
+++ b/server/src/like/like.integration.spec.ts
@@ -2,7 +2,7 @@ import * as request from 'supertest';
 import { Test } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
 import { MongoMemoryServer } from 'mongodb-memory-server';
-import { connect, Connection, Model } from 'mongoose';
+import { connect, Connection, Model, Types } from 'mongoose';
 import { getModelToken } from '@nestjs/mongoose';
 
 import { User, userSchema } from 'src/user/entities/user.entity';
@@ -33,6 +33,12 @@ describe('Like 모듈 통합 테스트', () => {
       .compile();
 
     app = module.createNestApplication();
+    app.use((req, res, next) => {
+      req.session = {
+        userId: new Types.ObjectId().toString(),
+      };
+      next();
+    });
     await app.init();
   });
 
@@ -51,7 +57,18 @@ describe('Like 모듈 통합 테스트', () => {
     }
   });
 
-  it('GET /api/like/:id', () => {
-    return request(app.getHttpServer()).get('/api/like/1').expect(200);
+  it('GET /api/like/:id', async () => {
+    const res = await request(app.getHttpServer())
+      .get('/api/like/1')
+      .expect(200);
+
+    console.log(res.body);
+  });
+
+  it('test', async () => {
+    const res = await request(app.getHttpServer()).post('/api/like');
+    // .send({ likedId: new Types.ObjectId().toString() });
+
+    console.log(res.body);
   });
 });

--- a/server/src/like/like.integration.spec.ts
+++ b/server/src/like/like.integration.spec.ts
@@ -1,0 +1,57 @@
+import * as request from 'supertest';
+import { Test } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import { connect, Connection, Model } from 'mongoose';
+import { getModelToken } from '@nestjs/mongoose';
+
+import { User, userSchema } from 'src/user/entities/user.entity';
+import { Like, likeSchema } from './entities/like.entity';
+import { LikeModule } from './like.module';
+
+describe('Like 모듈 통합 테스트', () => {
+  let app: INestApplication;
+  let mongod: MongoMemoryServer;
+  let mongoConnection: Connection;
+  let userModel: Model<User>;
+  let likeModel: Model<Like>;
+
+  beforeAll(async () => {
+    mongod = await MongoMemoryServer.create();
+    const uri = mongod.getUri();
+    mongoConnection = (await connect(uri)).connection;
+    userModel = mongoConnection.model(User.name, userSchema);
+    likeModel = mongoConnection.model(Like.name, likeSchema);
+
+    const module = await Test.createTestingModule({
+      imports: [LikeModule],
+    })
+      .overrideProvider(getModelToken(User.name))
+      .useValue(userModel)
+      .overrideProvider(getModelToken(Like.name))
+      .useValue(likeModel)
+      .compile();
+
+    app = module.createNestApplication();
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await mongoConnection.dropDatabase();
+    await mongoConnection.close();
+    await mongod.stop();
+    await app.close();
+  });
+
+  afterEach(async () => {
+    const collections = mongoConnection.collections;
+    for (const key in collections) {
+      const collection = collections[key];
+      await collection.deleteMany({});
+    }
+  });
+
+  it('GET /api/like/:id', () => {
+    return request(app.getHttpServer()).get('/api/like/1').expect(200);
+  });
+});

--- a/server/src/like/like.integration.spec.ts
+++ b/server/src/like/like.integration.spec.ts
@@ -1,6 +1,6 @@
 import * as request from 'supertest';
 import { Test } from '@nestjs/testing';
-import { INestApplication } from '@nestjs/common';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
 import { MongoMemoryServer } from 'mongodb-memory-server';
 import { connect, Connection, Model, Types } from 'mongoose';
 import { getModelToken } from '@nestjs/mongoose';
@@ -8,13 +8,43 @@ import { getModelToken } from '@nestjs/mongoose';
 import { User, userSchema } from 'src/user/entities/user.entity';
 import { Like, likeSchema } from './entities/like.entity';
 import { LikeModule } from './like.module';
+import { UserRepository } from 'src/user/user.repository';
+import { LikeRepository } from './like.repository';
+import { plainToInstance } from 'class-transformer';
+import { AddLikeRequestDto } from './dto/add-like.dto';
+import { HttpExceptionFilter } from 'src/common/http-execption-filter';
+import { DeleteLikeRequestDto } from './dto/delete-like.dto';
+
+const idOfUser1: string = new Types.ObjectId().toString();
+const idOfUser2: string = new Types.ObjectId().toString();
+const userStub1: User = {
+  authProvider: 'google',
+  authId: '1111',
+  email: 'aa@gmail.com',
+  username: 'user1',
+  _id: new Types.ObjectId(idOfUser1),
+  createdAt: '',
+  updatedAt: '',
+};
+const userStub2: User = {
+  authProvider: 'gmail',
+  authId: '2222',
+  email: 'bb@gmail.com',
+  username: 'user2',
+  _id: new Types.ObjectId(idOfUser2),
+  createdAt: '',
+  updatedAt: '',
+};
 
 describe('Like 모듈 통합 테스트', () => {
   let app: INestApplication;
   let mongod: MongoMemoryServer;
   let mongoConnection: Connection;
+  let userRepository: UserRepository;
+  let likeRepository: LikeRepository;
   let userModel: Model<User>;
   let likeModel: Model<Like>;
+  let savedLike1: Like;
 
   beforeAll(async () => {
     mongod = await MongoMemoryServer.create();
@@ -26,27 +56,40 @@ describe('Like 모듈 통합 테스트', () => {
     const module = await Test.createTestingModule({
       imports: [LikeModule],
     })
+      .overrideProvider(UserRepository)
+      .useClass(UserRepository)
+      .overrideProvider(LikeRepository)
+      .useClass(LikeRepository)
       .overrideProvider(getModelToken(User.name))
       .useValue(userModel)
       .overrideProvider(getModelToken(Like.name))
       .useValue(likeModel)
       .compile();
 
+    userRepository = module.get<UserRepository>(UserRepository);
+    likeRepository = module.get<LikeRepository>(LikeRepository);
     app = module.createNestApplication();
-    app.use((req, res, next) => {
-      req.session = {
-        userId: new Types.ObjectId().toString(),
-      };
-      next();
-    });
-    await app.init();
+    app.useGlobalFilters(new HttpExceptionFilter());
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+      }),
+    );
+  });
+
+  beforeEach(async () => {
+    await userRepository.create(userStub1);
+    await userRepository.create(userStub2);
+    savedLike1 = await likeRepository.create(idOfUser1);
+    await likeRepository.create(idOfUser2);
   });
 
   afterAll(async () => {
     await mongoConnection.dropDatabase();
     await mongoConnection.close();
     await mongod.stop();
-    await app.close();
   });
 
   afterEach(async () => {
@@ -57,18 +100,115 @@ describe('Like 모듈 통합 테스트', () => {
     }
   });
 
-  it('GET /api/like/:id', async () => {
-    const res = await request(app.getHttpServer())
-      .get('/api/like/1')
-      .expect(200);
+  describe('로그인 상태', () => {
+    beforeAll(async () => {
+      // 로그인 한 사용자 === user1
+      app.use((req, res, next) => {
+        req.session = {
+          userId: idOfUser1,
+        };
+        next();
+      });
+      await app.init();
+    });
 
-    console.log(res.body);
+    afterAll(async () => {
+      await app.close();
+    });
+
+    describe('POST /api/like 좋아요 리스트에 추가', () => {
+      it('200 응답, 좋아요 리스트에 추가 성공', async () => {
+        expect(savedLike1.likedIds).toEqual([]);
+
+        await request(app.getHttpServer())
+          .post('/api/like')
+          .send(plainToInstance(AddLikeRequestDto, { likedId: idOfUser2 }))
+          .expect(200, { code: 10000, message: '성공' });
+
+        const nextLikeOfUser1 = await likeRepository.findLikeByUserId(
+          idOfUser1,
+        );
+        expect(nextLikeOfUser1.likedIds).toEqual([idOfUser2]);
+      });
+
+      it('400 응답, likeDto 에 담긴 likedId 가 올바르지 않은 경우', async () => {
+        await request(app.getHttpServer())
+          .post('/api/like')
+          .send(
+            plainToInstance(AddLikeRequestDto, {
+              likedId: new Types.ObjectId().toString(),
+            }),
+          )
+          .expect(400, {
+            code: 20006,
+            message: '일치하는 유저 정보가 없습니다.',
+          });
+      });
+
+      it('400 응답, 중복된 사용자를 추가하고자 하는 경우', async () => {
+        //미리 user1 의 좋아요 리스트에 user2 의 id 추가
+        await likeRepository.updateLikeByLikedIds(idOfUser1, [idOfUser2]);
+        const likeOfUser1 = await likeRepository.findLikeByUserId(idOfUser1);
+        expect(likeOfUser1.likedIds).toEqual([idOfUser2]);
+
+        //user1 의 좋아요 리스트에 user2 의 id 추가 -> 400 에러 발생
+        await request(app.getHttpServer())
+          .post('/api/like')
+          .send(plainToInstance(AddLikeRequestDto, { likedId: idOfUser2 }))
+          .expect(400, {
+            code: 40001,
+            message: '이미 좋아요 리스트에 존재하는 사용자입니다.',
+          });
+      });
+    });
+
+    describe('DELETE /api/like 좋아요 리스트에서 삭제', () => {
+      it('200 응답, 좋아요 리스트에 삭제 성공', async () => {
+        await likeRepository.updateLikeByLikedIds(idOfUser1, [idOfUser2]);
+        const likeOfUser1 = await likeRepository.findLikeByUserId(idOfUser1);
+        expect(likeOfUser1.likedIds).toEqual([idOfUser2]);
+
+        await request(app.getHttpServer())
+          .delete('/api/like')
+          .send(plainToInstance(DeleteLikeRequestDto, { likedId: idOfUser2 }))
+          .expect(200, { code: 10000, message: '성공' });
+
+        const nextLikeOfUser1 = await likeRepository.findLikeByUserId(
+          idOfUser1,
+        );
+        expect(nextLikeOfUser1.likedIds).toEqual([]);
+      });
+
+      it('400 응답, likeDto 에 담긴 likedId 가 올바르지 않은 경우', async () => {
+        await request(app.getHttpServer())
+          .delete('/api/like')
+          .send(
+            plainToInstance(DeleteLikeRequestDto, {
+              likedId: new Types.ObjectId().toString(),
+            }),
+          )
+          .expect(400, {
+            code: 20006,
+            message: '일치하는 유저 정보가 없습니다.',
+          });
+      });
+    });
   });
 
-  it('test', async () => {
-    const res = await request(app.getHttpServer()).post('/api/like');
-    // .send({ likedId: new Types.ObjectId().toString() });
+  describe('비로그인 상태', () => {
+    beforeAll(async () => {
+      await app.init();
+    });
 
-    console.log(res.body);
+    afterAll(async () => {
+      await app.close();
+    });
+
+    it('401 응답, 로그인 상태가 아닌 경우(POST /api/like)', async () => {
+      request(app.getHttpServer())
+        .post('/api/like')
+        .send(plainToInstance(AddLikeRequestDto, { likedId: idOfUser2 }))
+        .expect(401, { code: 20003, message: '로그인 상태가 아닙니다.' });
+    });
   });
 });


### PR DESCRIPTION
## 📕 제목

https://github.com/boostcampwm-2022/web25-SCOPA/issues/95

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] SuperTest 관한 학습
   - [x] SuperTest 에 session 입력가능한 방법 찾기
- [x] POST `/api/like` API 테스트
   - [x] 200 응답, 성공한 경우
   - [x] 400 응답, likeDto 에 담긴 likedId 가 잘못된 경우
   - [x] 400 응답, 중복된 사용자를 추가하고자 하는 경우
   - [x] 401 응답, 로그인 상태가 아닌 경우
- [x] DELETE `/api/like` API 테스트
   - [x] 200 응답, 성공한 경우
   - [x] 400 응답, likeDto 에 담긴 likedId 가 잘못된 경우

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- `DELETE /api/like` 에 로그인 상태가 아닌 경우에 관한 테스트 코드는 `POST /api/like` 과 너무 동일해서 작성하지 않았습니다.
- `like.integration.spec.ts 설명`
   - Line 18~37 : 통합 테스트에 사용할 stub 데이터를 선언한 구간입니다.
   - Line 40~47 : 테스트에서 사용되는 변수들을 선언한 구간입니다.
   - Line 49~80 : 전체 테스트가 진행되기 이전에 테스트에 사용 될 module 을 설정하고, 설정된 모듈에서 `userRepository`, `likeRepository`, `app` 을 가져오는 부분입니다. `useGlobalFilters`는 CustomExceptionFilter 를 적용하는 부분입니다. `useGlobalPipes`은 request 로 오는 데이터의 validation 을 체크해주는 pipe 를 설정하는 부분입니다.
   - Line 82~87 : 각 테스트 이전에 테스트에 필요한 user 와 like document 를 DB 에 저장하는 구간입니다.
   - Line 89~93 : 모든 테스트가 끝나고, 켜놓은 테스트용 mongoDB 서버를 종료하는 구간입니다.
   - Line 95~101 : 각 테스트 이후에 DB 에 저장된 데이터를 초기화 시키는 구간입니다.
   - Line 104~113 : 로그인 상태로 만들기 위해 session 에 사용자 정보를 추가하는 구간입니다. 그 후 `app.init()`으로 테스트용 서버를 킵니다.
   - Line 115~117 : 모든 테스트 이후에 켜져있는 `app` 서버를 종료하는 구간입니다.
   - Line 119~ : 각 테스트를 진행하는 코드 구간입니다.